### PR TITLE
Phase 2: BQ column rename, member master, and Streamlit dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .envrc
 .gitconfig.local
 .sa-key.json
+dashboard/.streamlit/secrets.toml
 __pycache__/
 *.pyc
 .venv/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,89 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## プロジェクト概要
+
+GASベースの給与スプレッドシートデータ集約を、Cloud Run + BigQuery に移行したバッチ処理システム。
+毎朝6時にCloud Schedulerが起動し、約190件のスプレッドシートからデータを収集してBigQueryに書き込む。
+
+## アーキテクチャ
+
+```
+Cloud Scheduler (0 6 * * * JST, OIDC認証)
+  → Cloud Run "pay-collector" (Python 3.12 / Flask / gunicorn)
+    → Sheets API v4 (IAM signBlobによるキーレスDWD認証)
+    → BigQuery pay_reports.{gyomu_reports, hojo_reports} (WRITE_TRUNCATE)
+```
+
+認証はWorkload Identity + IAM signBlob APIによるキーレスDomain-Wide Delegation。
+SA鍵ファイルは使わない（ローカル開発時のみ `SA_KEY_PATH` 環境変数で鍵ファイル指定）。
+
+## ディレクトリ構成
+
+- `cloud-run/` - Cloud Runアプリケーション（本体）
+  - `main.py` - Flaskエントリポイント（`POST /` でバッチ実行、`GET /health`）
+  - `sheets_collector.py` - Sheets API経由のデータ収集（DWD認証含む）
+  - `bq_loader.py` - BigQueryへのデータロード（pandas DataFrame経由）
+  - `config.py` - GCPプロジェクトID、BQテーブル名、マスタスプレッドシートID等の設定値
+  - `tests/` - テストディレクトリ（未実装）
+- `コード.js` - 旧GASコード（参照用、稼働していない）
+- `infra/bigquery/schema.sql` - BQテーブルスキーマ定義
+- `infra/ar-cleanup-policy.json` - Artifact Registryクリーンアップポリシー
+- `docs/adr/` - Architecture Decision Records
+- `docs/handoff/LATEST.md` - ハンドオフドキュメント
+
+## ビルド・デプロイ
+
+```bash
+# Cloud Runへのデプロイ（cloud-run/ ディレクトリから）
+gcloud builds submit --tag asia-northeast1-docker.pkg.dev/monthly-pay-tax/cloud-run-images/pay-collector
+gcloud run deploy pay-collector \
+  --image asia-northeast1-docker.pkg.dev/monthly-pay-tax/cloud-run-images/pay-collector \
+  --platform managed --region asia-northeast1 --memory 2Gi --timeout 1800 \
+  --no-allow-unauthenticated
+```
+
+メモリは2GiB必須（190件巡回で512MBはOOM）。gunicornは1worker/1thread/1800sタイムアウト。
+
+## GCP環境
+
+| リソース | 値 |
+|---------|-----|
+| プロジェクト | `monthly-pay-tax` |
+| リージョン | `asia-northeast1` |
+| SA | `pay-collector@monthly-pay-tax.iam.gserviceaccount.com` |
+| Cloud Run URL | `https://pay-collector-209715990891.asia-northeast1.run.app` |
+| BQデータセット | `pay_reports` |
+| BQテーブル | `gyomu_reports`（業務報告）, `hojo_reports`（補助報告） |
+| AR | `cloud-run-images`（最新2イメージ保持） |
+
+## BQスキーマ
+
+3テーブル構成。すべてSTRING型 + ingested_at (TIMESTAMP)。
+
+- `gyomu_reports`: source_url, year, date, day_of_week, activity_category, work_category, sponsor, description, unit_price, hours, amount
+- `hojo_reports`: source_url, year, month, hours, compensation, dx_subsidy, reimbursement, total_amount, monthly_complete, dx_receipt, expense_receipt
+- `members`: report_url, member_id, nickname, gws_account, full_name, qualification_allowance, position_rate
+
+`source_url`（gyomu/hojo）= `report_url`（members）で結合してメンバー名を取得。
+
+## ダッシュボード
+
+`dashboard/` - Streamlitアプリ（別Cloud Runサービス `pay-dashboard`）
+
+- URL: `https://pay-dashboard-209715990891.asia-northeast1.run.app`
+- 512MiBメモリ、SA: `pay-collector@...`（BQ読み取り用）
+- 3タブ構成: 月別報酬サマリー / スポンサー別業務委託費 / 業務報告一覧
+- BQの `members` テーブルと結合してメンバー名を表示
+
+## 環境分離
+
+direnvで環境分離済み。`.envrc`で`GH_CONFIG_DIR`、`CLOUDSDK_ACTIVE_CONFIG_NAME`、`GCLOUD_PROJECT`を設定。
+GitHub CLIは`.gh/`ディレクトリ、gitユーザーは`.gitconfig.local`で管理。
+
+## 既知の技術的制約
+
+- Cloud RunのデフォルトSA認証（`google.auth.default()`）は`with_subject`非対応 → IAM signBlob API経由でキーレスDWD
+- バッチ処理は約217秒（190件巡回、gyomu: 14,029行 / hojo: 942行）
+- 毎回WRITE_TRUNCATEで全データ置換（差分更新ではない）

--- a/cloud-run/config.py
+++ b/cloud-run/config.py
@@ -9,12 +9,18 @@ GCP_PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "monthly-pay-tax")
 BQ_DATASET = os.environ.get("BQ_DATASET", "pay_reports")
 BQ_TABLE_GYOMU = "gyomu_reports"
 BQ_TABLE_HOJO = "hojo_reports"
+BQ_TABLE_MEMBERS = "members"
 
 # 管理表スプレッドシート
 MASTER_SPREADSHEET_ID = "1fBNfkFBARSpT-OpLOytbAfoa0Xo5LTWv7irimssxcUU"
 MASTER_SHEET_NAME = "報告シート（「説明用」以外はタダメンMから関数生成）M"
 URL_COLUMN_INDEX = 0  # A列
 URL_START_ROW = 2
+
+# GASバインドスプレッドシート（タダメンMマスタの所在）
+GAS_SPREADSHEET_ID = "16V9fs2kf2IzxdVz1GOJHY9mR1MmGjbmwm5L0ECiMLrc"
+MEMBER_SHEET_NAME = "タダメンM"
+MEMBER_START_ROW = 2  # 1行目はヘッダー
 
 # スキップ対象URL
 SKIP_URLS = [
@@ -45,3 +51,24 @@ SHEET_CONFIGS = [
         "num_columns": 10,
     },
 ]
+
+# テーブル別カラム名定義
+TABLE_COLUMNS = {
+    BQ_TABLE_GYOMU: [
+        "source_url",
+        "year", "date", "day_of_week",
+        "activity_category", "work_category", "sponsor",
+        "description", "unit_price", "hours", "amount",
+    ],
+    BQ_TABLE_HOJO: [
+        "source_url",
+        "year", "month", "hours",
+        "compensation", "dx_subsidy", "reimbursement",
+        "total_amount", "monthly_complete", "dx_receipt", "expense_receipt",
+    ],
+    BQ_TABLE_MEMBERS: [
+        "report_url", "member_id", "nickname",
+        "gws_account", "full_name",
+        "qualification_allowance", "position_rate",
+    ],
+}

--- a/dashboard/.dockerignore
+++ b/dashboard/.dockerignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.venv/
+.env
+.streamlit/

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.12-slim
+
+ENV PYTHONUNBUFFERED=True
+ENV APP_HOME=/app
+WORKDIR $APP_HOME
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD exec streamlit run app.py \
+    --server.port=$PORT \
+    --server.address=0.0.0.0 \
+    --server.headless=true \
+    --browser.gatherUsageStats=false

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,0 +1,559 @@
+"""月次報酬ダッシュボード
+
+BigQueryのpay_reportsデータセットを可視化するStreamlitアプリ。
+統計分析スプレッドシート「月別報酬＆源泉徴収」を中心に再現。
+Cloud IAP経由でtadakayo.jpドメインのみアクセス可能。
+"""
+
+import streamlit as st
+from google.cloud import bigquery
+
+st.set_page_config(
+    page_title="タダカヨ 月次報酬ダッシュボード",
+    page_icon="📊",
+    layout="wide",
+)
+
+# --- カスタムCSS ---
+st.markdown("""
+<style>
+    /* ヘッダー */
+    .dashboard-header {
+        padding: 0.5rem 0 1rem 0;
+        border-bottom: 2px solid #0EA5E9;
+        margin-bottom: 1rem;
+    }
+    .dashboard-header h1 {
+        font-size: 1.6rem;
+        font-weight: 700;
+        margin: 0;
+        letter-spacing: 0.02em;
+    }
+    .dashboard-header .user-email {
+        font-size: 0.8rem;
+        opacity: 0.6;
+        margin-top: 0.2rem;
+    }
+
+    /* KPIカード */
+    .kpi-card {
+        border: 1px solid rgba(14, 165, 233, 0.3);
+        border-radius: 8px;
+        padding: 1rem 1.2rem;
+        background: linear-gradient(135deg, rgba(14, 165, 233, 0.08) 0%, rgba(14, 165, 233, 0.02) 100%);
+        margin-bottom: 0.5rem;
+    }
+    .kpi-card .kpi-label {
+        font-size: 0.75rem;
+        font-weight: 500;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        opacity: 0.6;
+        margin-bottom: 0.3rem;
+    }
+    .kpi-card .kpi-value {
+        font-size: 1.5rem;
+        font-weight: 700;
+        color: #0EA5E9;
+        line-height: 1.2;
+    }
+
+    /* サイドバー */
+    section[data-testid="stSidebar"] {
+        width: 280px !important;
+    }
+    section[data-testid="stSidebar"] .stSelectbox label,
+    section[data-testid="stSidebar"] .stTextInput label {
+        font-size: 0.8rem;
+        font-weight: 600;
+        letter-spacing: 0.03em;
+    }
+    .sidebar-section-title {
+        font-size: 0.7rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        opacity: 0.5;
+        margin: 1rem 0 0.3rem 0;
+        padding-top: 0.8rem;
+        border-top: 1px solid rgba(255,255,255,0.1);
+    }
+
+    /* タブ */
+    .stTabs [data-baseweb="tab-list"] {
+        gap: 0;
+    }
+    .stTabs [data-baseweb="tab"] {
+        padding: 0.6rem 1.5rem;
+        font-weight: 600;
+        font-size: 0.85rem;
+    }
+
+    /* データフレーム */
+    .stDataFrame {
+        border-radius: 6px;
+        overflow: hidden;
+    }
+
+    /* 件数バッジ */
+    .count-badge {
+        display: inline-block;
+        background: rgba(14, 165, 233, 0.15);
+        color: #0EA5E9;
+        font-weight: 700;
+        font-size: 0.85rem;
+        padding: 0.3rem 0.8rem;
+        border-radius: 20px;
+        margin-bottom: 0.5rem;
+    }
+
+    /* 選択カウント */
+    .member-count {
+        font-size: 0.75rem;
+        opacity: 0.5;
+        margin-top: 0.2rem;
+    }
+</style>
+""", unsafe_allow_html=True)
+
+
+# --- IAP認証情報取得 ---
+def get_iap_user_email() -> str:
+    """Cloud IAPが設定するヘッダーからユーザーメールを取得"""
+    headers = st.context.headers
+    return headers.get("X-Goog-Authenticated-User-Email", "").replace("accounts.google.com:", "")
+
+
+PROJECT_ID = "monthly-pay-tax"
+DATASET = "pay_reports"
+
+
+def valid_years(series):
+    """年カラムから有効な年（2020-2030の整数）のみ抽出"""
+    def to_year(v):
+        try:
+            y = int(float(v))
+            return y if 2020 <= y <= 2030 else None
+        except (ValueError, TypeError):
+            return None
+    return series.apply(to_year)
+
+
+def fill_empty_nickname(df):
+    """空のnicknameを「(未設定)」に置換"""
+    df["nickname"] = df["nickname"].fillna("").apply(lambda x: x.strip() if x else "")
+    df.loc[df["nickname"] == "", "nickname"] = "(未設定)"
+    return df
+
+
+def clean_numeric(series):
+    """文字列の数値カラムをfloatに変換（通貨記号, カンマ, スプレッドシートエラー対応）"""
+    cleaned = (
+        series.astype(str)
+        .str.replace("¥", "", regex=False)
+        .str.replace("＄", "", regex=False)
+        .str.replace("$", "", regex=False)
+        .str.replace(",", "", regex=False)
+        .str.strip()
+    )
+    def safe_float(x):
+        if not x or x in ("", "None", "nan") or x.startswith("#"):
+            return 0.0
+        try:
+            return float(x)
+        except (ValueError, TypeError):
+            return 0.0
+    return cleaned.apply(safe_float)
+
+
+def render_kpi(label: str, value: str):
+    """カスタムKPIカードを描画"""
+    st.markdown(f"""
+    <div class="kpi-card">
+        <div class="kpi-label">{label}</div>
+        <div class="kpi-value">{value}</div>
+    </div>
+    """, unsafe_allow_html=True)
+
+
+@st.cache_resource
+def get_bq_client():
+    return bigquery.Client(project=PROJECT_ID)
+
+
+@st.cache_data(ttl=3600)
+def load_data(query: str):
+    client = get_bq_client()
+    return client.query(query).to_dataframe()
+
+
+# --- データ読み込み ---
+@st.cache_data(ttl=3600)
+def load_hojo_with_members():
+    """補助報告 + メンバー名を結合して取得"""
+    query = f"""
+    SELECT
+        m.nickname,
+        m.full_name,
+        h.year,
+        h.month,
+        h.hours,
+        h.compensation,
+        h.dx_subsidy,
+        h.reimbursement,
+        h.total_amount,
+        h.monthly_complete,
+        m.qualification_allowance,
+        m.position_rate
+    FROM `{PROJECT_ID}.{DATASET}.hojo_reports` h
+    LEFT JOIN `{PROJECT_ID}.{DATASET}.members` m
+        ON h.source_url = m.report_url
+    WHERE h.year IS NOT NULL
+    ORDER BY h.year, h.month
+    """
+    return load_data(query)
+
+
+@st.cache_data(ttl=3600)
+def load_gyomu_with_members():
+    """業務報告 + メンバー名を結合して取得"""
+    query = f"""
+    SELECT
+        m.nickname,
+        g.year,
+        g.date,
+        g.day_of_week,
+        g.activity_category,
+        g.work_category,
+        g.sponsor,
+        g.description,
+        g.unit_price,
+        g.hours,
+        g.amount
+    FROM `{PROJECT_ID}.{DATASET}.gyomu_reports` g
+    LEFT JOIN `{PROJECT_ID}.{DATASET}.members` m
+        ON g.source_url = m.report_url
+    WHERE g.year IS NOT NULL
+        AND (g.date IS NOT NULL OR g.amount IS NOT NULL)
+    ORDER BY g.year, g.date
+    """
+    return load_data(query)
+
+
+# --- サイドバー ---
+with st.sidebar:
+    st.markdown("### 📊 タダカヨ")
+    st.caption("月次報酬ダッシュボード")
+    user_email = get_iap_user_email()
+    if user_email:
+        st.markdown(f"<div style='font-size:0.8rem; opacity:0.6; margin-bottom:1rem;'>{user_email}</div>",
+                    unsafe_allow_html=True)
+    st.divider()
+
+    # 年選択
+    st.markdown('<div class="sidebar-section-title">期間</div>', unsafe_allow_html=True)
+    # 年リストはデータロード前にデフォルト値を設定、タブ内で使用
+    all_years = list(range(2024, 2027))
+    selected_year = st.selectbox("年度", all_years, index=len(all_years) - 1, key="global_year")
+    month_options = ["全月"] + [f"{m}月" for m in range(1, 13)]
+    selected_month = st.selectbox("月", month_options, key="global_month")
+
+    # メンバー選択
+    st.markdown('<div class="sidebar-section-title">メンバー</div>', unsafe_allow_html=True)
+    member_search = st.text_input("検索", key="member_search", placeholder="名前で絞り込み...",
+                                  label_visibility="collapsed")
+
+    # データから全メンバーリストを構築
+    @st.cache_data(ttl=3600)
+    def load_all_members():
+        query = f"""
+        SELECT nickname, has_empty FROM (
+            SELECT DISTINCT nickname, FALSE AS has_empty FROM (
+                SELECT m.nickname
+                FROM `{PROJECT_ID}.{DATASET}.hojo_reports` h
+                LEFT JOIN `{PROJECT_ID}.{DATASET}.members` m ON h.source_url = m.report_url
+                UNION DISTINCT
+                SELECT m.nickname
+                FROM `{PROJECT_ID}.{DATASET}.gyomu_reports` g
+                LEFT JOIN `{PROJECT_ID}.{DATASET}.members` m ON g.source_url = m.report_url
+            )
+            WHERE nickname IS NOT NULL AND TRIM(nickname) != ''
+            UNION ALL
+            SELECT '(未設定)' AS nickname, TRUE AS has_empty FROM (
+                SELECT 1 FROM (
+                    SELECT m.nickname
+                    FROM `{PROJECT_ID}.{DATASET}.hojo_reports` h
+                    LEFT JOIN `{PROJECT_ID}.{DATASET}.members` m ON h.source_url = m.report_url
+                    WHERE m.nickname IS NULL OR TRIM(m.nickname) = ''
+                    UNION ALL
+                    SELECT m.nickname
+                    FROM `{PROJECT_ID}.{DATASET}.gyomu_reports` g
+                    LEFT JOIN `{PROJECT_ID}.{DATASET}.members` m ON g.source_url = m.report_url
+                    WHERE m.nickname IS NULL OR TRIM(m.nickname) = ''
+                ) LIMIT 1
+            )
+        )
+        ORDER BY has_empty DESC, nickname
+        """
+        return load_data(query)["nickname"].tolist()
+
+    try:
+        all_members = load_all_members()
+    except Exception:
+        all_members = []
+
+    if member_search:
+        display_members = [m for m in all_members if member_search.lower() in m.lower()]
+    else:
+        display_members = all_members
+
+    col_a, col_b = st.columns(2)
+    with col_a:
+        if st.button("全選択", key="sb_all", use_container_width=True):
+            for m in display_members:
+                st.session_state[f"sb_{m}"] = True
+    with col_b:
+        if st.button("全解除", key="sb_clear", use_container_width=True):
+            for m in display_members:
+                st.session_state[f"sb_{m}"] = False
+
+    selected_members = []
+    with st.container(height=250):
+        for m in display_members:
+            if st.checkbox(m, key=f"sb_{m}"):
+                selected_members.append(m)
+
+    count = len(selected_members)
+    total = len(all_members)
+    if count == 0:
+        st.caption(f"全 {total} 名表示中")
+    else:
+        st.caption(f"{count} / {total} 名を選択中")
+
+
+# --- ヘッダー ---
+st.markdown("""
+<div class="dashboard-header">
+    <h1>月次報酬ダッシュボード</h1>
+</div>
+""", unsafe_allow_html=True)
+
+
+# --- タブ ---
+tab1, tab2, tab3 = st.tabs([
+    "月別報酬＆源泉徴収",
+    "スポンサー別業務委託費",
+    "業務報告一覧",
+])
+
+
+# ===== Tab 1: 月別報酬＆源泉徴収 =====
+with tab1:
+    try:
+        df_hojo = load_hojo_with_members()
+    except Exception as e:
+        st.error(f"データ取得エラー: {e}")
+        st.stop()
+
+    if df_hojo.empty:
+        st.info("データがありません")
+    else:
+        df_hojo = fill_empty_nickname(df_hojo)
+        for col in ["hours", "compensation", "dx_subsidy", "reimbursement", "total_amount"]:
+            df_hojo[col] = clean_numeric(df_hojo[col])
+
+        df_hojo["year"] = valid_years(df_hojo["year"])
+        df_hojo = df_hojo[df_hojo["year"].notna()]
+        df_hojo["year"] = df_hojo["year"].astype(int)
+        df_hojo["month"] = df_hojo["month"].apply(
+            lambda x: int(float(x)) if str(x).replace(".", "").isdigit() and 1 <= int(float(x)) <= 12 else None
+        )
+
+        filtered = df_hojo[df_hojo["year"] == selected_year]
+        if selected_month != "全月":
+            filtered = filtered[filtered["month"] == int(selected_month.replace("月", ""))]
+        if selected_members:
+            filtered = filtered[filtered["nickname"].isin(selected_members)]
+
+        # KPIカード
+        k1, k2, k3, k4 = st.columns(4)
+        with k1:
+            render_kpi("総報酬", f"¥{filtered['compensation'].sum():,.0f}")
+        with k2:
+            render_kpi("総時間", f"{filtered['hours'].sum():,.1f}h")
+        with k3:
+            render_kpi("DX補助", f"¥{filtered['dx_subsidy'].sum():,.0f}")
+        with k4:
+            render_kpi("総額合計", f"¥{filtered['total_amount'].sum():,.0f}")
+
+        # メンバー×月ピボット
+        st.subheader("メンバー別 月次総額")
+        pivot = filtered.pivot_table(
+            values="total_amount",
+            index="nickname",
+            columns="month",
+            aggfunc="sum",
+            fill_value=0,
+        )
+        pivot.columns = pivot.columns.astype(str)
+        month_order = sorted(pivot.columns, key=lambda x: int(float(x)) if x.replace(".", "").isdigit() else 99)
+        pivot = pivot[month_order]
+        pivot["年間合計"] = pivot.sum(axis=1)
+        pivot = pivot.sort_values("年間合計", ascending=False)
+        st.dataframe(
+            pivot.style.format("¥{:,.0f}"),
+            use_container_width=True,
+        )
+
+        # 月次推移チャート
+        st.subheader("月次報酬推移")
+        monthly = filtered.groupby("month").agg(
+            報酬=("compensation", "sum"),
+            DX補助=("dx_subsidy", "sum"),
+            立替=("reimbursement", "sum"),
+        ).reset_index()
+        monthly["month"] = monthly["month"].apply(
+            lambda x: int(float(x)) if str(x).replace(".", "").isdigit() else 0
+        )
+        monthly = monthly.sort_values("month")
+        monthly = monthly.set_index("month")
+        st.bar_chart(monthly[["報酬", "DX補助", "立替"]])
+
+
+# ===== Tab 2: スポンサー別業務委託費 =====
+with tab2:
+    try:
+        df_gyomu = load_gyomu_with_members()
+    except Exception as e:
+        st.error(f"データ取得エラー: {e}")
+        st.stop()
+
+    if df_gyomu.empty:
+        st.info("データがありません")
+    else:
+        df_gyomu = fill_empty_nickname(df_gyomu)
+        df_gyomu["amount_num"] = clean_numeric(df_gyomu["amount"])
+        df_gyomu["month_num"] = df_gyomu["date"].astype(str).apply(
+            lambda x: x.split("/")[0] if "/" in str(x) else ""
+        )
+        df_gyomu["year"] = valid_years(df_gyomu["year"])
+        df_gyomu = df_gyomu[df_gyomu["year"].notna()]
+        df_gyomu["year"] = df_gyomu["year"].astype(int)
+
+        filtered_g = df_gyomu[df_gyomu["year"] == selected_year]
+
+        # タブ内フィルター（スポンサーのみ）
+        sponsors = filtered_g["sponsor"].dropna().unique().tolist()
+        sponsors = [s for s in sponsors if s and s.strip()]
+
+        col_sp, col_spacer = st.columns([1, 3])
+        with col_sp:
+            selected_sponsor = st.selectbox(
+                "スポンサー",
+                ["全スポンサー"] + sorted(sponsors),
+                key="gyomu_sponsor",
+                label_visibility="collapsed",
+            )
+
+        if selected_sponsor != "全スポンサー":
+            filtered_g = filtered_g[filtered_g["sponsor"] == selected_sponsor]
+        if selected_members:
+            filtered_g = filtered_g[filtered_g["nickname"].isin(selected_members)]
+
+        # KPIカード
+        k1, k2, k3 = st.columns(3)
+        with k1:
+            render_kpi("総額", f"¥{filtered_g['amount_num'].sum():,.0f}")
+        with k2:
+            render_kpi("件数", f"{len(filtered_g):,}")
+        with k3:
+            render_kpi("メンバー数", f"{filtered_g['nickname'].nunique()}")
+
+        # ピボット
+        st.subheader("メンバー別 月次金額")
+        if not filtered_g.empty:
+            pivot_g = filtered_g.pivot_table(
+                values="amount_num",
+                index="nickname",
+                columns="month_num",
+                aggfunc="sum",
+                fill_value=0,
+            )
+            month_order_g = sorted(
+                pivot_g.columns,
+                key=lambda x: int(x) if x.isdigit() else 99,
+            )
+            pivot_g = pivot_g[month_order_g]
+            pivot_g["年間合計"] = pivot_g.sum(axis=1)
+            pivot_g = pivot_g.sort_values("年間合計", ascending=False)
+            st.dataframe(
+                pivot_g.style.format("¥{:,.0f}"),
+                use_container_width=True,
+            )
+
+        # 活動分類別サマリー
+        st.subheader("活動分類別 金額")
+        cat_summary = (
+            filtered_g.groupby("activity_category")["amount_num"]
+            .sum()
+            .sort_values(ascending=False)
+        )
+        if not cat_summary.empty:
+            st.bar_chart(cat_summary)
+
+
+# ===== Tab 3: 業務報告一覧 =====
+with tab3:
+    try:
+        df_gyomu_all = load_gyomu_with_members()
+    except Exception as e:
+        st.error(f"データ取得エラー: {e}")
+        st.stop()
+
+    if df_gyomu_all.empty:
+        st.info("データがありません")
+    else:
+        df_gyomu_all = fill_empty_nickname(df_gyomu_all)
+        df_gyomu_all["year"] = valid_years(df_gyomu_all["year"])
+        df_gyomu_all = df_gyomu_all[df_gyomu_all["year"].notna()]
+        df_gyomu_all["year"] = df_gyomu_all["year"].astype(int)
+
+        result = df_gyomu_all[df_gyomu_all["year"] == selected_year]
+
+        # タブ内フィルター
+        categories = ["全分類"] + sorted(
+            result["activity_category"].dropna().unique().tolist()
+        )
+        col_cat, col_spacer = st.columns([1, 3])
+        with col_cat:
+            sel_cat = st.selectbox("活動分類", categories, key="list_cat", label_visibility="collapsed")
+
+        if selected_members:
+            result = result[result["nickname"].isin(selected_members)]
+        if sel_cat != "全分類":
+            result = result[result["activity_category"] == sel_cat]
+
+        st.markdown(f'<div class="count-badge">{len(result):,} 件</div>', unsafe_allow_html=True)
+        st.dataframe(
+            result[
+                [
+                    "nickname", "date", "day_of_week",
+                    "activity_category", "work_category",
+                    "sponsor", "description",
+                    "unit_price", "hours", "amount",
+                ]
+            ].rename(columns={
+                "nickname": "メンバー",
+                "date": "日付",
+                "day_of_week": "曜日",
+                "activity_category": "活動分類",
+                "work_category": "業務分類",
+                "sponsor": "スポンサー",
+                "description": "内容",
+                "unit_price": "単価",
+                "hours": "時間",
+                "amount": "金額",
+            }),
+            use_container_width=True,
+            hide_index=True,
+        )

--- a/dashboard/requirements.txt
+++ b/dashboard/requirements.txt
@@ -1,0 +1,5 @@
+streamlit==1.50.0
+google-cloud-bigquery==3.27.0
+pandas==2.2.3
+pyarrow==18.1.0
+db-dtypes==1.3.1

--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,37 +1,53 @@
 # ハンドオフメモ - monthly-pay-tax
 
-**更新日**: 2026-02-07
-**フェーズ**: 1 - Cloud Run + BigQuery 本番稼働中
+**更新日**: 2026-02-08
+**フェーズ**: 2 - BQリネーム + ダッシュボード + タダメンM取込（コミット準備完了）
 
 ## 現在の状態
 
-GASからCloud Run + BigQueryへの移行が完了し、本番稼働中。毎朝6時にCloud Schedulerが自動実行。
+Cloud Run + BigQuery本番稼働中。Streamlitダッシュボードもデプロイ済み。
+BQカラム名を意味のある英語名にリネーム完了。タダメンMマスタの取込を追加。
+monthly_compensation（統計分析SS）関連コードのロールバック完了。
 
-### 完了済み
+### 判明事項
 
-| 項目 | 状態 | 詳細 |
-|------|------|------|
-| GASコードのclasp clone | ✅ | アカウント: yasushi-honda@tadakayo.jp |
-| GitHubリポジトリ | ✅ | yasushi-honda-prog/monthly-pay-tax (public) |
-| GCPプロジェクト | ✅ | `monthly-pay-tax` |
-| 環境分離 | ✅ | .envrc, .gitconfig.local, gcloud config |
-| GCP API有効化 | ✅ | BigQuery, Sheets, Run, AR, Scheduler, Build |
-| サービスアカウント | ✅ | `pay-collector@monthly-pay-tax.iam.gserviceaccount.com` |
-| Domain-Wide Delegation | ✅ | Workload Identity + IAM signBlob（キーレス） |
-| BigQueryスキーマ | ✅ | `pay_reports.gyomu_reports`, `pay_reports.hojo_reports` |
-| Cloud Run デプロイ | ✅ | v2, 2GiB メモリ, asia-northeast1 |
-| Cloud Scheduler | ✅ | 毎朝6時JST、OIDC認証 |
-| Artifact Registry | ✅ | クリーンアップポリシー: 最新2イメージ保持 |
-| E2Eテスト | ✅ | 190件巡回、gyomu: 14,029行、hojo: 942行、217.5秒 |
-| ADR-0001 | ✅ | アーキテクチャ決定記録 |
+1. **タダメンM F/G列は元データが空** → qualification_allowance / position_rate のNULLは正常
+2. **position_rate / qualification_allowance** は統計分析SSの数式内にのみ存在
+3. **統計分析SSはBQデータソースとして不適** → インタラクティブ単月表示ツール
 
-### 未完了
+### スプレッドシートの役割整理
 
-| 項目 | 優先度 | 備考 |
-|------|--------|------|
-| Looker Studio接続 | 高 | BQネイティブコネクタで接続 |
-| BQカラム名の意味付け | 中 | col_b~col_kを実際のフィールド名に変更 |
-| Gitコミット＆push | 高 | 今セッションの変更をコミット |
+| SS | 用途 | BQ取り込み |
+|----|------|-----------|
+| 管理表（`1fBN...`） | URLリスト | URLのみ |
+| 190個の個別報告SS | gyomu/hojoデータ | ✅ 対象 |
+| GASバインドSS（`16V9...`） | タダメンMマスタ | ✅ 対象 |
+| 統計分析SS（`1Kyv...`） | **参照・確認用** | ❌ 対象外 |
+
+### 本ブランチの変更内容
+
+| ファイル | 変更内容 |
+|---------|---------|
+| .gitignore | dashboard/.streamlit/secrets.toml 除外追加 |
+| cloud-run/bq_loader.py | 汎用カラム名対応（TABLE_COLUMNS参照に変更） |
+| cloud-run/config.py | BQ_TABLE_MEMBERS追加、GAS SS設定追加、TABLE_COLUMNS定義追加 |
+| cloud-run/sheets_collector.py | DWD分離リファクタ、httplib2 timeout追加、collect_members()追加 |
+| dashboard/ | Streamlitダッシュボード新規作成（3タブ構成） |
+| infra/bigquery/schema.sql | 意味のあるカラム名スキーマ |
+| docs/handoff/LATEST.md | ハンドオフ更新 |
+| CLAUDE.md | プロジェクト設定ファイル |
+
+### 次のアクション
+
+1. **BQのmonthly_compensationテーブル削除** → `bq rm monthly-pay-tax:pay_reports.monthly_compensation`
+2. **SAキー削除**: `431e84cf48b58c4b119e0f6ba6a3a742338ede1f`（一時作成の残骸）
+3. **再デプロイ** → ロールバック済みコードをCloud Runに反映
+4. **将来課題**: position_rate/qualification_allowanceの取得方法検討（タダメンMにデータ投入 or 別途マスタ管理）
+
+### デプロイ済み状態
+
+- **Collector**: 旧コード（monthly_compensation込み）でデプロイ中 → 再デプロイ必要
+- **Dashboard**: 旧コード（monthly_compensation参照あり）でデプロイ中 → 再デプロイ必要
 
 ## アーキテクチャ
 
@@ -39,31 +55,23 @@ GASからCloud Run + BigQueryへの移行が完了し、本番稼働中。毎朝
 Cloud Scheduler (毎朝6時JST)
     │ OIDC認証
     ▼
-Cloud Run (Python 3.12 / Flask / gunicorn)
+Cloud Run "pay-collector" (Python 3.12 / Flask / gunicorn / 2GiB)
     ├─ Workload Identity + IAM signBlob でDWD認証
     ├─ 管理表 → 190件のURLリスト取得
     ├─ 各スプレッドシート巡回 → Sheets API v4 でデータ収集
+    ├─ タダメンMマスタ取得
     ├─ pandas DataFrame に整形
     └─ BigQuery に load_table_from_dataframe (WRITE_TRUNCATE)
           │
           ▼
     BigQuery (pay_reports dataset)
-    ├─ gyomu_reports: 14,029行
-    └─ hojo_reports: 942行
+    ├─ gyomu_reports: ~18,800行（業務報告）
+    ├─ hojo_reports: ~1,000行（補助＆立替報告）
+    └─ members: 190行（タダメンMマスタ）
           │
           ▼
-    Looker Studio（未接続）
+Cloud Run "pay-dashboard" (Streamlit / 512MiB)
 ```
-
-## GCPリソース一覧
-
-| リソース | 名前 | リージョン |
-|---------|------|----------|
-| Cloud Run | pay-collector | asia-northeast1 |
-| BigQuery Dataset | pay_reports | asia-northeast1 |
-| Artifact Registry | cloud-run-images | asia-northeast1 |
-| Cloud Scheduler | pay-collector-daily | asia-northeast1 |
-| Service Account | pay-collector | - |
 
 ## 環境情報
 
@@ -72,6 +80,17 @@ Cloud Run (Python 3.12 / Flask / gunicorn)
 | GCPプロジェクトID | `monthly-pay-tax` |
 | GCPアカウント | yasushi-honda@tadakayo.jp |
 | GitHub | yasushi-honda-prog/monthly-pay-tax |
-| Cloud Run URL | `https://pay-collector-209715990891.asia-northeast1.run.app` |
+| Collector URL | `https://pay-collector-209715990891.asia-northeast1.run.app` |
+| Dashboard URL | `https://pay-dashboard-209715990891.asia-northeast1.run.app` |
 | SA Email | `pay-collector@monthly-pay-tax.iam.gserviceaccount.com` |
-| DWD Client ID | `105293708004584950257` |
+| ⚠️ 残SAキー | `431e84cf48b58c4b119e0f6ba6a3a742338ede1f`（要削除） |
+
+## BQスキーマ
+
+**gyomu_reports**: source_url, year, date, day_of_week, activity_category, work_category, sponsor, description, unit_price, hours, amount, ingested_at
+
+**hojo_reports**: source_url, year, month, hours, compensation, dx_subsidy, reimbursement, total_amount, monthly_complete, dx_receipt, expense_receipt, ingested_at
+
+**members**: report_url, member_id, nickname, gws_account, full_name, qualification_allowance(⚠️ALL NULL), position_rate(⚠️ALL NULL), ingested_at
+
+結合キー: `source_url` (gyomu/hojo) = `report_url` (members)

--- a/infra/bigquery/schema.sql
+++ b/infra/bigquery/schema.sql
@@ -1,38 +1,49 @@
 -- BigQuery スキーマ定義
 -- データセット: pay_reports
--- GASの元データ: B~K列（10列）+ 先頭にURL付加 = 11列
 
 -- データセット作成
 -- bq mk --dataset --location=asia-northeast1 monthly-pay-tax:pay_reports
 
 -- 【都度入力】業務報告
 CREATE TABLE IF NOT EXISTS `monthly-pay-tax.pay_reports.gyomu_reports` (
-  source_url STRING NOT NULL,       -- 元スプレッドシートURL
-  col_b STRING,                     -- B列
-  col_c STRING,                     -- C列
-  col_d STRING,                     -- D列
-  col_e STRING,                     -- E列
-  col_f STRING,                     -- F列
-  col_g STRING,                     -- G列
-  col_h STRING,                     -- H列
-  col_i STRING,                     -- I列
-  col_j STRING,                     -- J列
-  col_k STRING,                     -- K列
-  ingested_at TIMESTAMP NOT NULL    -- データ取得日時
+  source_url STRING NOT NULL,            -- 元スプレッドシートURL
+  year STRING,                           -- 年
+  date STRING,                           -- 月日（例: 6/30）
+  day_of_week STRING,                    -- 曜日
+  activity_category STRING,              -- 活動分類（タダスク, 法人本部 等）
+  work_category STRING,                  -- 業務分類（タダスク研修講師 等）
+  sponsor STRING,                        -- スポンサー
+  description STRING,                    -- 業務内容
+  unit_price STRING,                     -- 業務単価（円/h）
+  hours STRING,                          -- 所要時間（H）
+  amount STRING,                         -- 金額
+  ingested_at TIMESTAMP NOT NULL         -- データ取得日時
 );
 
 -- 【月１入力】補助＆立替報告＋月締め
 CREATE TABLE IF NOT EXISTS `monthly-pay-tax.pay_reports.hojo_reports` (
-  source_url STRING NOT NULL,       -- 元スプレッドシートURL
-  col_b STRING,                     -- B列
-  col_c STRING,                     -- C列
-  col_d STRING,                     -- D列
-  col_e STRING,                     -- E列
-  col_f STRING,                     -- F列
-  col_g STRING,                     -- G列
-  col_h STRING,                     -- H列
-  col_i STRING,                     -- I列
-  col_j STRING,                     -- J列
-  col_k STRING,                     -- K列
-  ingested_at TIMESTAMP NOT NULL    -- データ取得日時
+  source_url STRING NOT NULL,            -- 元スプレッドシートURL
+  year STRING,                           -- 年
+  month STRING,                          -- 月
+  hours STRING,                          -- 時間
+  compensation STRING,                   -- 報酬
+  dx_subsidy STRING,                     -- DX補助
+  reimbursement STRING,                  -- 立替
+  total_amount STRING,                   -- 総額
+  monthly_complete STRING,               -- 当月入力完了フラグ
+  dx_receipt STRING,                     -- DX補助用 領収書添付欄
+  expense_receipt STRING,                -- 個人立替用 領収書添付欄
+  ingested_at TIMESTAMP NOT NULL         -- データ取得日時
+);
+
+-- タダメンMマスタ（メンバー情報）
+CREATE TABLE IF NOT EXISTS `monthly-pay-tax.pay_reports.members` (
+  report_url STRING NOT NULL,            -- 報告シートURL（gyomu/hojoのsource_urlと結合キー）
+  member_id STRING,                      -- タダメンID
+  nickname STRING,                       -- ニックネーム
+  gws_account STRING,                    -- GWSアカウント
+  full_name STRING,                      -- 本名
+  qualification_allowance STRING,        -- 資格手当
+  position_rate STRING,                  -- 役職手当率
+  ingested_at TIMESTAMP NOT NULL         -- データ取得日時
 );


### PR DESCRIPTION
## Summary
- BQカラム名を汎用名（col_b..col_k）から意味のある英語名にリネーム
- タダメンMマスタ収集を追加（190名 → BQ membersテーブル）
- DWD認証を`_get_dwd_credentials()`にリファクタ＋httplib2タイムアウト追加
- Streamlitダッシュボード新規作成（月別報酬サマリー / スポンサー別 / 業務報告一覧）
- CLAUDE.mdプロジェクト設定追加
- monthly_compensation関連コード削除（統計分析SSはインタラクティブツールであり、データソースではないと判明）

## Changes
| ファイル | 変更内容 |
|---------|---------|
| cloud-run/config.py | members設定、TABLE_COLUMNS定義追加 |
| cloud-run/sheets_collector.py | DWD分離、httplib2 timeout、collect_members()追加 |
| cloud-run/bq_loader.py | 汎用カラム名対応に変更 |
| infra/bigquery/schema.sql | 意味のあるカラム名スキーマ |
| dashboard/ | Streamlitアプリ新規作成 |
| CLAUDE.md | プロジェクト設定 |

## Test plan
- [ ] Cloud Run pay-collector再デプロイ後、BQテーブルのカラム名確認
- [ ] membersテーブルに190行ロードされることを確認
- [ ] ダッシュボード再デプロイ後、3タブ正常表示確認
- [ ] monthly_compensationテーブルの手動削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)