### PR TITLE
Add donation_payment column to Tab1 detail table

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -460,6 +460,7 @@ with tab1:
             DX補助=("dx_subsidy", "sum"),
             立替=("reimbursement", "sum"),
             支払い=("payment", "sum"),
+            寄付支払い=("donation_payment", "sum"),
         ).sort_values("支払い", ascending=False)
         st.dataframe(
             detail.style.format({
@@ -474,6 +475,7 @@ with tab1:
                 "DX補助": "¥{:,.0f}",
                 "立替": "¥{:,.0f}",
                 "支払い": "¥{:,.0f}",
+                "寄付支払い": "¥{:,.0f}",
             }),
             use_container_width=True,
         )


### PR DESCRIPTION
## Summary
- Tab1メンバー別報酬明細テーブルに「寄付支払い」カラムを追加
- v_monthly_compensation VIEWで計算済みのdonation_paymentがダッシュボード表示から漏れていた

## Test plan
- [ ] ダッシュボードTab1の明細テーブルに「寄付支払い」列が表示されること
- [ ] 寄付メンバーの寄付支払い金額が正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)