### PR TITLE
Fix total_work_hours calculation for daily wage entries

### DIFF
--- a/infra/bigquery/views.sql
+++ b/infra/bigquery/views.sql
@@ -51,14 +51,12 @@ SELECT
     WHEN REGEXP_CONTAINS(g.work_category, r'日給制') THEN 1
     ELSE NULL
   END AS daily_wage_flag,
-  -- 総稼働時間: 所要時間 + 全日稼働(+6h) / 半日稼働(+3h)
-  SAFE_CAST(
-    CASE WHEN g.work_category = '自家用車使用' THEN NULL ELSE g.hours END
-    AS FLOAT64
-  ) + CASE
+  -- 総稼働時間: 全日稼働→6h / 半日稼働→3h に置換、それ以外は所要時間
+  CASE
+    WHEN g.work_category = '自家用車使用' THEN NULL
     WHEN REGEXP_CONTAINS(g.work_category, r'全日稼働') THEN 6.0
     WHEN REGEXP_CONTAINS(g.work_category, r'半日稼働') THEN 3.0
-    ELSE 0.0
+    ELSE SAFE_CAST(g.hours AS FLOAT64)
   END AS total_work_hours,
   g.ingested_at
 FROM `monthly-pay-tax.pay_reports.gyomu_reports` g


### PR DESCRIPTION
## Summary
- v_gyomu_enriched VIEW の total_work_hours 計算を修正: 全日/半日稼働の時間を「加算」から「置換」に変更
- 参考スプレッドシート（統計分析SS）との照合で系統的不一致を解消
- 12メンバーの total_work_hours が正確に一致するようになった（マッチ率 93%→95%）

## Details
全日稼働（※日給制）の行で work_hours=1.0 の場合:
- **修正前**: 1.0 + 6.0 = 7.0（加算）
- **修正後**: 6.0（置換、SS準拠）

同様に半日稼働: 1.0 + 3.0 = 4.0 → 3.0 に修正。

## Test plan
- [x] BQ VIEW デプロイ済み（v_gyomu_enriched + v_monthly_compensation）
- [x] さゆりん（90.15）、しろくま（38.75）、瓊玲（43.5）、みずいろ（17.3）でSS値と完全一致を確認
- [x] 既存の計算チェーン（payment, withholding_tax 等）に影響なし（total_work_hours は表示専用）

🤖 Generated with [Claude Code](https://claude.com/claude-code)