### PR TITLE
Migrate dashboard auth from IAP to Streamlit OIDC

### DIFF
--- a/dashboard/requirements.txt
+++ b/dashboard/requirements.txt
@@ -1,4 +1,5 @@
 streamlit==1.50.0
+Authlib==1.6.5
 google-cloud-bigquery==3.27.0
 pandas==2.2.3
 pyarrow==18.1.0


### PR DESCRIPTION
## Summary
- Cloud IAP + 自己署名証明書(sslip.io) → Streamlit OIDC(st.login/st.user) + Cloud Run *.run.app(Google管理SSL)に認証方式を移行
- OAuth認証情報をSecret Managerに保存し、Cloud Runにファイルマウント
- 旧LBインフラ(forwarding-rule, proxy, url-map, backend-service, cert, NEG, static IP)を全削除済み

## Test plan
- [x] Secret Manager作成 + SA権限付与
- [x] Cloud Runデプロイ(ingress=all, allUsers:run.invoker, Secret Managerマウント)
- [x] SSL証明書が正規(Google管理)であることを確認
- [x] Googleログインフロー動作確認(tadakayo.jpドメイン)
- [x] BQホワイトリスト照合 + admin/viewerページ表示確認
- [x] 旧LBインフラ削除後もダッシュボード正常動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)