### PR TITLE
Replace streamlit-mermaid with Mermaid.js CDN for dark mode support

### DIFF
--- a/dashboard/requirements.txt
+++ b/dashboard/requirements.txt
@@ -4,4 +4,3 @@ google-cloud-bigquery==3.27.0
 pandas==2.2.3
 pyarrow==18.1.0
 db-dtypes==1.3.1
-streamlit-mermaid==0.2.0


### PR DESCRIPTION
## Summary
- `streamlit-mermaid` ライブラリを `st.html()` + Mermaid.js v11 CDN に置き換え
- ダークモード自動検出（`prefers-color-scheme` + Streamlit固有クラス）に対応
- erDiagramの `PK` アノテーション削除でパースエラーを解消

## Test plan
- [ ] ダッシュボードにログインし、アーキテクチャページで全5図が正常表示されること
- [ ] ライトモードで適切な配色（青系）であること
- [ ] ダークモードで適切な配色（暗い背景 + 明るいテキスト）であること
- [ ] erDiagram（BQスキーマ）がエラーなく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)