### PR TITLE
Fix Mermaid rendering with larger diagrams and dark mode

### DIFF
--- a/dashboard/pages/architecture.py
+++ b/dashboard/pages/architecture.py
@@ -1,46 +1,62 @@
 """アーキテクチャドキュメント（Mermaid図 + 説明）"""
 
 import streamlit as st
+import streamlit.components.v1 as components
 
 
-def render_mermaid(code: str, height: int = 400):
+def render_mermaid(code: str, height: int = 500):
     """Mermaid図をダークモード対応でレンダリング"""
     html = f"""
-    <div id="mermaid-container">
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
+        <style>
+            body {{
+                background: transparent;
+                margin: 0;
+                padding: 0;
+                display: flex;
+                justify-content: center;
+                align-items: flex-start;
+            }}
+            .mermaid {{
+                width: 100%;
+            }}
+            .mermaid svg {{
+                width: 100% !important;
+                max-height: {height - 20}px;
+            }}
+        </style>
+    </head>
+    <body>
         <pre class="mermaid">{code}</pre>
-    </div>
-    <script type="module">
-        import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-        const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches
-            || document.body.classList.contains('stAppDark')
-            || document.documentElement.getAttribute('data-theme') === 'dark';
-        mermaid.initialize({{
-            startOnLoad: true,
-            theme: isDark ? 'dark' : 'default',
-            themeVariables: isDark ? {{
-                primaryColor: '#1e3a5f',
-                primaryTextColor: '#e0e0e0',
-                lineColor: '#4a9eff',
-                secondaryColor: '#2d2d2d',
-                tertiaryColor: '#1a1a2e',
-            }} : {{
-                primaryColor: '#e8f4fd',
-                primaryTextColor: '#1a1a1a',
-                lineColor: '#0EA5E9',
-            }},
-            flowchart: {{ curve: 'basis', padding: 20 }},
-            fontSize: 14,
-        }});
-    </script>
-    <style>
-        #mermaid-container {{
-            display: flex;
-            justify-content: center;
-            padding: 1rem 0;
-        }}
-    </style>
+        <script>
+            const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            mermaid.initialize({{
+                startOnLoad: true,
+                theme: isDark ? 'dark' : 'default',
+                themeVariables: isDark ? {{
+                    primaryColor: '#1e3a5f',
+                    primaryTextColor: '#e0e0e0',
+                    lineColor: '#4a9eff',
+                    secondaryColor: '#2d2d2d',
+                    tertiaryColor: '#1a1a2e',
+                    fontSize: '18px',
+                }} : {{
+                    primaryColor: '#e8f4fd',
+                    primaryTextColor: '#1a1a1a',
+                    lineColor: '#0EA5E9',
+                    fontSize: '18px',
+                }},
+                flowchart: {{ curve: 'basis', padding: 20, nodeSpacing: 50, rankSpacing: 60 }},
+                fontSize: 18,
+            }});
+        </script>
+    </body>
+    </html>
     """
-    st.html(html)
+    components.html(html, height=height)
 
 
 st.header("アーキテクチャ")
@@ -62,7 +78,7 @@ graph LR
     BQ -->|VIEWs| DB[Cloud Run<br/>pay-dashboard]
     BR[ブラウザ] -->|HTTPS *.run.app| DB
     DB -->|Streamlit OIDC<br/>Google OAuth| GOOG[Google IdP<br/>tadakayo.jp]
-""")
+""", height=350)
 
 st.markdown("""
 | コンポーネント | 仕様 |
@@ -96,7 +112,7 @@ graph TD
     BQ --> VH[v_hojo_enriched]
     VG --> VMC[v_monthly_compensation]
     VH --> VMC
-""")
+""", height=600)
 
 
 # === 3. BQスキーマ ER図 ===
@@ -143,7 +159,7 @@ erDiagram
         STRING role
         STRING display_name
     }
-""", height=500)
+""", height=650)
 
 
 # === 4. VIEW計算チェーン ===
@@ -162,7 +178,7 @@ graph TD
     CTE5[base_calc<br/>小計 → 役職手当 → 資格手当] --> CTE6
     CTE6[with_tax<br/>源泉対象額 → 源泉徴収] --> FINAL
     FINAL[最終SELECT<br/>支払い = 報酬 + 源泉 + DX + 立替]
-""")
+""", height=550)
 
 st.markdown("""
 | CTE | 内容 | 主要カラム |
@@ -192,4 +208,4 @@ graph TD
     BQ -->|BQ障害時| FB{フォールバック}
     FB -->|初期管理者| ADMIN
     FB -->|その他| DENY
-""")
+""", height=600)

--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,14 +1,24 @@
 # ハンドオフメモ - monthly-pay-tax
 
 **更新日**: 2026-02-09
-**フェーズ**: 6 - 認証方式移行（IAP → Streamlit OIDC）
+**フェーズ**: 6完了 + Mermaid図修正
 
 ## 現在の状態
 
 Cloud Run + BigQuery + Streamlitダッシュボード本番稼働中。
 ダッシュボードをマルチページ化し、BQベースのユーザー認可、アーキテクチャドキュメント、管理設定を追加。
 
-### 今回の変更（Phase 6: IAP → Streamlit OIDC移行）
+### 今回の変更（PR #10: Mermaid図レンダリング修正）
+
+1. **`streamlit-mermaid` → `components.html()` + Mermaid.js v11 CDN**: サードパーティライブラリを廃止し、CDN直接読み込みに変更
+2. **ダークモード対応**: `prefers-color-scheme` メディアクエリでライト/ダーク自動切替
+3. **erDiagram PKアノテーション削除**: パースエラーの原因だった `PK` を除去
+4. **図のサイズ改善**: SVG幅100%、フォント18px、ノード間隔拡大、各図の高さを個別設定
+5. **`streamlit-mermaid==0.2.0` を requirements.txt から削除**
+
+**技術的教訓**: `st.html()` はsandboxed iframeでESMモジュールインポートがブロックされる → `streamlit.components.v1.html()` + 通常の `<script>` タグで解決
+
+### 前回の変更（Phase 6: IAP → Streamlit OIDC移行）
 
 1. **認証方式変更**: Cloud IAP → Streamlit OIDC（Google OAuth, `st.login`/`st.user`）
 2. **アクセスURL変更**: `sslip.io`（自己署名証明書） → `*.run.app`（Google管理SSL証明書）
@@ -18,7 +28,7 @@ Cloud Run + BigQuery + Streamlitダッシュボード本番稼働中。
 6. **Secret Manager**: `dashboard-auth-config` → `/app/.streamlit/secrets.toml`にマウント
 7. **Cloud Run設定**: `ingress=all` + `allUsers:run.invoker`（アプリ層で認証）
 
-### 前回までの変更（Phase 5: Dashboard Multipage）
+### Phase 5: Dashboard Multipage
 
 1. **マルチページ化**: app.py（649行） → app.py（ルーター ~50行） + pages/ + lib/
 2. **BQユーザー認可**: `dashboard_users` テーブル + IAP email照合 + admin/viewer ロール
@@ -33,7 +43,7 @@ Cloud Run + BigQuery + Streamlitダッシュボード本番稼働中。
 ```
 dashboard/
   app.py                    # エントリポイント: 認証 + st.navigation ルーター
-  requirements.txt          # streamlit-mermaid 追加
+  requirements.txt          # Mermaid.js CDN利用（streamlit-mermaid廃止）
   pages/
     dashboard.py            # 既存3タブ（app.pyから抽出）
     architecture.py         # Mermaidアーキテクチャ図
@@ -86,7 +96,7 @@ gcloud run deploy pay-dashboard \
 ### デプロイ済み状態
 
 - **Collector**: rev 00013（members A:K対応 + 先行読み取り）
-- **Dashboard**: rev 00029（Streamlit OIDC認証、Secret Managerマウント）
+- **Dashboard**: rev 00034（Mermaid.js CDN + ダークモード + 図サイズ改善）
 - **BQ VIEWs**: v_gyomu_enriched, v_hojo_enriched, v_monthly_compensation デプロイ済み
 - **BQ Table**: withholding_targets, dashboard_users シードデータ投入済み
 


### PR DESCRIPTION
## Summary
- `st.html()` → `streamlit.components.v1.html()` でESMモジュールブロック問題を修正
- 図のサイズを大幅拡大（フォント18px、SVG幅100%、各図の高さ個別設定）
- ハンドオフドキュメントを更新

## Test plan
- [x] 全5図がレンダリングされること（PR #10で未レンダリングだった問題を修正）
- [x] 図が大きく見やすいこと（スクロールなしで閲覧可能）
- [x] ダークモードで適切な配色
- [x] デプロイ済み（rev 00034）で動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)