### PR TITLE
Improve check management UX with status buttons and navigation

### DIFF
--- a/dashboard/lib/styles.py
+++ b/dashboard/lib/styles.py
@@ -100,6 +100,28 @@ CUSTOM_CSS = """
         opacity: 0.5;
         margin-top: 0.2rem;
     }
+
+    /* チェック管理: ワークフローヒント */
+    .check-flow-hint {
+        background: rgba(14, 165, 233, 0.06);
+        border-left: 3px solid #0EA5E9;
+        padding: 0.5rem 0.8rem;
+        border-radius: 0 6px 6px 0;
+        font-size: 0.82rem;
+        margin: 0.3rem 0 0.8rem 0;
+        opacity: 0.85;
+        line-height: 1.5;
+    }
+
+    /* チェック管理: メンバーカード内ステータスセクション */
+    .status-section-label {
+        font-size: 0.75rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        opacity: 0.5;
+        margin-bottom: 0.4rem;
+    }
 </style>
 """
 


### PR DESCRIPTION
## Summary
- 進捗バーを追加（KPIカード下にチェック完了率を表示）
- ステータス変更をselectboxからボタン式に変更（ワンクリックで即座に更新）
- 「次の未確認へ」ナビゲーションボタンを追加（未確認メンバーへのジャンプ）
- ワークフローヒントを追加（操作方法の案内テキスト）
- メンバー選択ドロップダウンにステータスアイコンを表示

## Test plan
- [ ] 業務チェックページにアクセスし、進捗バーが表示されることを確認
- [ ] ステータスボタン（未確認/確認中/確認完了/差戻し）のクリックで状態が変わることを確認
- [ ] 「次の未確認へ」ボタンで未確認メンバーにジャンプできることを確認
- [ ] メモの保存・操作ログが正常に動作することを確認
- [ ] ダッシュボードページに影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)