### PR TITLE
fix: 管理設定のBQテーブル最終更新時間をJST表記に修正

### DIFF
--- a/dashboard/pages/admin_settings.py
+++ b/dashboard/pages/admin_settings.py
@@ -1,7 +1,11 @@
 """管理設定ページ（管理者のみ）"""
 
+from datetime import timezone, timedelta
+
 import streamlit as st
 from google.cloud import bigquery
+
+JST = timezone(timedelta(hours=9))
 
 from lib.auth import require_admin, clear_role_cache
 from lib.bq_client import get_bq_client, load_data
@@ -46,7 +50,7 @@ try:
                 "テーブル": table_name,
                 "行数": f"{table.num_rows:,}",
                 "サイズ": f"{table.num_bytes / 1024 / 1024:.1f} MB" if table.num_bytes else "-",
-                "最終更新": table.modified.strftime("%Y-%m-%d %H:%M") if table.modified else "-",
+                "最終更新": table.modified.astimezone(JST).strftime("%Y-%m-%d %H:%M") if table.modified else "-",
             })
         except Exception:
             rows.append({


### PR DESCRIPTION
## Summary
- 管理設定ページの「BigQuery テーブル情報」最終更新時間がUTC表示だったのをJST(+9h)に修正

## 変更内容
- `table.modified` (UTC) を `astimezone(JST)` で変換して表示
- 標準ライブラリ `datetime.timezone` を使用（外部依存なし）

## Test plan
- [ ] `/admin_settings` の最終更新時間が日本時間で表示されることを確認

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)