### PR TITLE
docs: WAM要件ドキュメントとIssues #54-58 の相互リンク整備

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -56,18 +56,29 @@ docs/requirements/
    - 新規VIEW: `v_reimbursement_enriched` + `v_wam_monthly_summary`
    - 既存の分析系・ダッシュボードは無変更
 
+### GitHub Issues（追跡用）
+
+| Issue | 優先度 | 内容 | ブロック |
+|-------|-------|------|---------|
+| [#54](https://github.com/yasushi-honda-prog/monthly-pay-tax/issues/54) | **P0** | WAM Phase 0: ステークホルダー合意形成（18項目Q&A） | Blocks #55〜#58 |
+| [#55](https://github.com/yasushi-honda-prog/monthly-pay-tax/issues/55) | P1 | WAM要件① 領収書の自動生成と振込一括化 (Must) | Blocked by #54 |
+| [#56](https://github.com/yasushi-honda-prog/monthly-pay-tax/issues/56) | P1 | WAM要件② 振込データ抽出とCSV出力（GMOあおぞら） (Must) | Blocked by #54 |
+| [#57](https://github.com/yasushi-honda-prog/monthly-pay-tax/issues/57) | P1 | WAM要件③ WAM月別報酬・源泉徴収確認ツール (Must) | Blocked by #54 |
+| [#58](https://github.com/yasushi-honda-prog/monthly-pay-tax/issues/58) | P2 | WAM要件④ 支払調書作成ツールへの連携 (Want) | Blocked by #54 |
+
 ### 次セッションの開始点
 
-**Phase 0（合意形成）未完** のため、次セッションは **コード実装には入らない**。以下のいずれかから再開:
+**Phase 0（合意形成、#54）未完** のため、次セッションは **コード実装には入らない**。以下のいずれかから再開:
 
-1. **E**: ゆりさん（近藤ゆり）向けSlackメッセージ下書き作成（`QUESTIONS_20260411` の Q-E群 + Q-B群を一気に解消）
+1. **E**: ゆりさん（近藤ゆり）向けSlackメッセージ下書き作成（`QUESTIONS_20260411` の Q-E群 + Q-B群を一気に解消、Issue #54 のP0項目を進める）
 2. **F**: ミヤヤさん向けGoogle Docコメント返信下書き作成（`REQ_20260409` の相談事項4項目への技術回答）
-3. **一次評価レポート**: 現行 `gyomu_reports` / `hojo_reports` が要件③の月別確認ツールをどこまで実現可能か、30分でレポート作成
+3. **一次評価レポート**: 現行 `gyomu_reports` / `hojo_reports` が要件③（#57）の月別確認ツールをどこまで実現可能か、30分でレポート作成
 
 **着手前に必読**:
 - `docs/requirements/REQ_20260409_wam-grant-workflow.md` セクション7 実装ロードマップ
 - `docs/requirements/REF_20260411_reimbursement-sheet-discovery.md` セクション4〜7
 - `docs/requirements/QUESTIONS_20260411_wam-phase0.md` 全体
+- Issues #54〜#58 の Description
 
 ---
 

--- a/docs/requirements/QUESTIONS_20260411_wam-phase0.md
+++ b/docs/requirements/QUESTIONS_20260411_wam-phase0.md
@@ -5,6 +5,7 @@
 | 作成日 | 2026-04-11 |
 | 目的 | `REQ_20260409_wam-grant-workflow.md` Phase 0（合意形成）で解消すべき未確定事項の一覧 |
 | 想定回答期限 | 要: WAM対象期間（2026-04-01〜2027-03-31）の最初の振込タイミング前 |
+| 追跡Issue | [#54 WAM Phase 0: ステークホルダー合意形成](https://github.com/yasushi-honda-prog/monthly-pay-tax/issues/54) |
 | 関連資料 | [REQ_20260409](./REQ_20260409_wam-grant-workflow.md), [REF_20260408](./REF_20260408_wam-accounting-issues.md), [REF_20260409_mtg](./REF_20260409_wam-accounting-mtg.md), [REF_20260411_discovery](./REF_20260411_reimbursement-sheet-discovery.md) |
 
 ---

--- a/docs/requirements/REQ_20260409_wam-grant-workflow.md
+++ b/docs/requirements/REQ_20260409_wam-grant-workflow.md
@@ -5,8 +5,18 @@
 | 起票日 | 2026-04-09 |
 | 起票者 | WAM助成金事業事務局（ミヤヤさん） |
 | 相談先 | すごいシステムつくり隊（ヤススさん） |
-| ステータス | 要件受領（一次評価未実施） |
+| ステータス | 要件受領（一次評価済み、Phase 0 未着手） |
 | 原本 | [Google Doc](https://docs.google.com/document/d/1zg6ceu1ABP6TKxGiHbplBG--9db6FmVcmf3Wro3ekDc/edit) |
+
+## 関連GitHub Issues
+
+| Issue | 優先度 | 内容 |
+|-------|-------|------|
+| [#54](https://github.com/yasushi-honda-prog/monthly-pay-tax/issues/54) | **P0** | WAM Phase 0: ステークホルダー合意形成（18項目Q&A） |
+| [#55](https://github.com/yasushi-honda-prog/monthly-pay-tax/issues/55) | P1 | WAM要件① 領収書の自動生成と振込一括化 (Must) |
+| [#56](https://github.com/yasushi-honda-prog/monthly-pay-tax/issues/56) | P1 | WAM要件② 振込データ抽出とCSV出力（GMOあおぞら銀行）(Must) |
+| [#57](https://github.com/yasushi-honda-prog/monthly-pay-tax/issues/57) | P1 | WAM要件③ WAM月別報酬・源泉徴収確認ツール (Must) |
+| [#58](https://github.com/yasushi-honda-prog/monthly-pay-tax/issues/58) | P2 | WAM要件④ 支払調書作成ツールへの連携 (Want) |
 
 ## 参考資料
 


### PR DESCRIPTION
## Summary

- PR #53 で受領したWAM要件ドキュメントに、後から作成したGitHub Issues #54〜#58 への参照を追加
- 次セッション（別AIが引き継ぐ場合も含む）が起動直後にアクション項目を把握できるようにする
- **コード変更なし、ドキュメントのみ**

## 背景

PR #53 マージ後のセッション内で、CLAUDE.md MUSTルール「複数タスク受領 → 実装前に個別Issue化」に従い Issues #54〜#58 を作成。ドキュメント側に Issue への参照が無かったため、相互リンクを整備する。

## 変更内容

| ファイル | 変更 |
|---------|------|
| `docs/requirements/REQ_20260409_wam-grant-workflow.md` | 冒頭に「関連GitHub Issues」テーブルを追加（#54〜#58、優先度付き） |
| `docs/requirements/QUESTIONS_20260411_wam-phase0.md` | ヘッダーに追跡Issue #54 を明記 |
| `docs/handoff/LATEST.md` | Issues テーブルを「次セッションの開始点」前に追加、各アクションから対応Issueへのリンク |

## 関連Issue一覧

| Issue | 優先度 | 内容 |
|-------|-------|------|
| #54 | P0 | WAM Phase 0: ステークホルダー合意形成（18項目Q&A） |
| #55 | P1 | WAM要件① 領収書の自動生成と振込一括化 (Must) |
| #56 | P1 | WAM要件② 振込データ抽出とCSV出力（GMOあおぞら銀行）(Must) |
| #57 | P1 | WAM要件③ WAM月別報酬・源泉徴収確認ツール (Must) |
| #58 | P2 | WAM要件④ 支払調書作成ツールへの連携 (Want) |

## Test plan

- [x] リンク整合性: Issue番号が実在することを確認
- [x] ドキュメント内の優先度記載が Issue ラベルと一致することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)