### PR TITLE
feat: WAM確認ページにWAMフィルタとCSVダウンロード追加

### DIFF
--- a/dashboard/_pages/wam_monthly.py
+++ b/dashboard/_pages/wam_monthly.py
@@ -93,6 +93,13 @@ with st.sidebar:
 if selected_project != "すべて":
     df = df[df["target_project"] == selected_project]
 
+# --- サイドバー: WAM対象フィルタ ---
+with st.sidebar:
+    wam_only = st.checkbox("WAM対象のみ表示", key="wam_only")
+
+if wam_only and "is_wam" in df.columns:
+    df = df[df["is_wam"] == True]  # noqa: E712
+
 # --- KPI ---
 cols = st.columns(4)
 with cols[0]:
@@ -148,6 +155,16 @@ with tab2:
             hide_index=True,
         )
         st.caption(f"{len(df_detail):,} 件表示")
+
+        # CSVダウンロード
+        csv_data = df_detail[existing_cols].rename(columns=col_labels).to_csv(index=False)
+        st.download_button(
+            "CSVダウンロード",
+            csv_data,
+            file_name=f"wam_reimbursement_{selected_year}_{selected_month:02d}.csv",
+            mime="text/csv",
+            key="wam_csv_download",
+        )
 
 with tab3:
     st.subheader("領収書添付状況")

--- a/dashboard/tests/test_pages_wam_monthly.py
+++ b/dashboard/tests/test_pages_wam_monthly.py
@@ -149,3 +149,36 @@ class TestReceiptStats:
         stats = _receipt_stats(df)
         assert stats["attached"] == 0
         assert stats["missing"] == 3
+
+
+# --- WAMフィルタ ---
+
+class TestWamFilter:
+    def test_filter_wam_only(self):
+        df = pd.DataFrame({
+            "normalized_year": [2026, 2026, 2026],
+            "month": [4, 4, 4],
+            "is_wam": [True, False, True],
+            "payment_amount_numeric": [10000.0, 5000.0, 3000.0],
+        })
+        filtered = df[df["is_wam"] == True]  # noqa: E712
+        assert len(filtered) == 2
+        assert filtered["payment_amount_numeric"].sum() == 13000.0
+
+    def test_filter_wam_all_false(self):
+        df = pd.DataFrame({
+            "is_wam": [False, False, False],
+            "payment_amount_numeric": [10000.0, 5000.0, 3000.0],
+        })
+        filtered = df[df["is_wam"] == True]  # noqa: E712
+        assert len(filtered) == 0
+
+    def test_filter_wam_missing_column(self):
+        """is_wamカラムがない場合はフィルタしない"""
+        df = pd.DataFrame({
+            "payment_amount_numeric": [10000.0, 5000.0],
+        })
+        # is_wamカラムがなければフィルタをスキップ（アプリの動作と同じ）
+        if "is_wam" in df.columns:
+            df = df[df["is_wam"] == True]  # noqa: E712
+        assert len(df) == 2


### PR DESCRIPTION
## Summary
- サイドバーに「WAM対象のみ表示」チェックボックスを追加（is_wamフィルタ）
- Tab 2 メンバー別明細にCSVダウンロードボタンを追加
- Phase 0回答待ち中の先行準備。wam_flag更新後に即座に活用可能

## Test plan
- [x] Dashboard 213テスト全PASS
- [x] Cloud Run 42テスト全PASS
- [x] WAMフィルタ用テスト3件追加（is_wam=True/False/カラムなし）
- [ ] デプロイ後ブラウザ確認: WAMフィルタチェックボックスの動作
- [ ] デプロイ後ブラウザ確認: CSVダウンロードの動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)