### PR TITLE
feat: 支払明細書PDF生成機能追加 (Closes #55)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ SA鍵ファイルは使わない（ローカル開発時のみ `SA_KEY_PATH` 環
 ## テスト
 
 ```bash
-# Dashboard テスト（221テスト）— プロジェクトルートから実行可能
+# Dashboard テスト（231テスト）— プロジェクトルートから実行可能
 python3 -m pytest dashboard/tests/ -q
 
 # Cloud Run テスト（42テスト）— プロジェクトルートから実行可能

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ SA鍵ファイルは使わない（ローカル開発時のみ `SA_KEY_PATH` 環
 ## テスト
 
 ```bash
-# Dashboard テスト（231テスト）— プロジェクトルートから実行可能
+# Dashboard テスト（235テスト）— プロジェクトルートから実行可能
 python3 -m pytest dashboard/tests/ -q
 
 # Cloud Run テスト（42テスト）— プロジェクトルートから実行可能

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -10,7 +10,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 # 日本語フォント（支払明細書PDF生成用）
 RUN apt-get update && \
     apt-get install -y --no-install-recommends fonts-noto-cjk && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    ls /usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc > /dev/null
 
 # Google翻訳を無効化: StreamlitのHTMLテンプレートにtranslate="no"を埋め込む
 RUN sed -i 's|<html|<html translate="no" lang="ja"|' \

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -7,6 +7,11 @@ WORKDIR $APP_HOME
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
+# 日本語フォント（支払明細書PDF生成用）
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends fonts-noto-cjk && \
+    rm -rf /var/lib/apt/lists/*
+
 # Google翻訳を無効化: StreamlitのHTMLテンプレートにtranslate="no"を埋め込む
 RUN sed -i 's|<html|<html translate="no" lang="ja"|' \
     /usr/local/lib/python3.12/site-packages/streamlit/static/index.html

--- a/dashboard/_pages/wam_monthly.py
+++ b/dashboard/_pages/wam_monthly.py
@@ -11,6 +11,7 @@ import streamlit as st
 from lib.auth import require_admin
 from lib.bq_client import load_data
 from lib.constants import MONTHLY_COMPENSATION_VIEW, REIMBURSEMENT_VIEW
+from lib.receipt_pdf import generate_all_statements_zip, generate_payment_statement
 from lib.ui_helpers import fill_empty_nickname, render_kpi, render_sidebar_year_month
 
 # --- 認証チェック ---
@@ -188,7 +189,7 @@ with cols[3]:
     render_kpi("領収書添付率", f"{stats['rate']:.0f}%")
 
 # --- タブ ---
-tab1, tab2, tab3, tab4 = st.tabs(["PJ別サマリー", "メンバー別明細", "領収書添付状況", "月別報酬・振込確認"])
+tab1, tab2, tab3, tab4, tab5 = st.tabs(["PJ別サマリー", "メンバー別明細", "領収書添付状況", "月別報酬・振込確認", "支払明細書"])
 
 with tab1:
     st.subheader("対象PJ別 立替金サマリー")
@@ -321,3 +322,85 @@ with tab4:
                 key="wam_transfer_csv_download",
             )
         st.caption("※ 振込CSVの口座情報（銀行番号・支店番号・口座番号）は未入力です。ダウンロード後に手動で補完してください。")
+
+with tab5:
+    st.subheader("支払明細書")
+    if not comp_loaded or df_comp.empty:
+        st.info("報酬データがありません（支払明細書の生成には報酬データが必要です）")
+    else:
+        # メンバー選択
+        comp_members = sorted(df_comp["nickname"].dropna().unique().tolist())
+        selected_stmt_member = st.selectbox(
+            "メンバー選択", ["全メンバー"] + comp_members, key="wam_stmt_member",
+        )
+
+        if selected_stmt_member == "全メンバー":
+            # 全メンバーサマリー
+            st.caption(f"{len(comp_members):,} 名分の支払明細書を一括生成します")
+            zip_bytes = generate_all_statements_zip(
+                members_comp=df_comp,
+                reimbursement_df=df,
+                year=selected_year,
+                month=selected_month,
+            )
+            st.download_button(
+                "全メンバー一括ダウンロード (ZIP)",
+                zip_bytes,
+                file_name=f"payment_statements_{selected_year}_{selected_month:02d}.zip",
+                mime="application/zip",
+                key="wam_stmt_zip_download",
+            )
+        else:
+            # 個別メンバー
+            member_comp = df_comp[df_comp["nickname"] == selected_stmt_member].iloc[0]
+            member_reimb = df[df["nickname"] == selected_stmt_member] if not df.empty else pd.DataFrame()
+
+            comp_data = {
+                "qualification_adjusted_compensation": float(member_comp.get("qualification_adjusted_compensation", 0) or 0),
+                "withholding_tax": float(member_comp.get("withholding_tax", 0) or 0),
+                "dx_subsidy": float(member_comp.get("dx_subsidy", 0) or 0),
+                "reimbursement": float(member_comp.get("reimbursement", 0) or 0),
+                "payment": float(member_comp.get("payment", 0) or 0),
+            }
+
+            # プレビュー
+            cols5 = st.columns(3)
+            with cols5[0]:
+                subtotal_a = (
+                    comp_data["qualification_adjusted_compensation"]
+                    + comp_data["withholding_tax"]
+                    + comp_data["dx_subsidy"]
+                )
+                render_kpi("業務委託費 (A)", f"¥{subtotal_a:,.0f}")
+            with cols5[1]:
+                subtotal_b = member_reimb["payment_amount_numeric"].sum() if not member_reimb.empty else 0
+                render_kpi("立替経費 (B)", f"¥{subtotal_b:,.0f}")
+            with cols5[2]:
+                render_kpi("合計 (A+B)", f"¥{subtotal_a + subtotal_b:,.0f}")
+
+            # PDF生成・ダウンロード
+            full_name = str(member_comp.get("full_name", selected_stmt_member))
+            pdf_bytes = generate_payment_statement(
+                member_name=selected_stmt_member,
+                full_name=full_name,
+                year=selected_year,
+                month=selected_month,
+                compensation=comp_data,
+                reimbursement_items=member_reimb,
+            )
+            st.download_button(
+                "支払明細書PDFダウンロード",
+                pdf_bytes,
+                file_name=f"payment_statement_{selected_stmt_member}_{selected_year}_{selected_month:02d}.pdf",
+                mime="application/pdf",
+                key="wam_stmt_pdf_download",
+            )
+
+            # 領収書URL一覧
+            if not member_reimb.empty and "receipt_url" in member_reimb.columns:
+                urls = member_reimb["receipt_url"].dropna()
+                urls = urls[urls.str.strip() != ""]
+                if not urls.empty:
+                    with st.expander(f"添付書類一覧（{len(urls)}件）"):
+                        for i, url in enumerate(urls, 1):
+                            st.markdown(f"{i}. {url}")

--- a/dashboard/_pages/wam_monthly.py
+++ b/dashboard/_pages/wam_monthly.py
@@ -5,6 +5,8 @@ PJ別サマリー・メンバー別明細・領収書添付状況を表示する
 v_monthly_compensation VIEW から報酬・源泉徴収データを表示する。
 """
 
+import io
+
 import pandas as pd
 import streamlit as st
 
@@ -151,7 +153,8 @@ try:
     ).fillna(0)
     df_comp = _filter_comp_by_year_month(df_comp_all, selected_year, selected_month)
     comp_loaded = True
-except Exception:
+except Exception as e:
+    st.warning(f"報酬データの取得に失敗しました: {e}")
     df_comp = pd.DataFrame()
     comp_loaded = False
 
@@ -323,6 +326,25 @@ with tab4:
             )
         st.caption("※ 振込CSVの口座情報（銀行番号・支店番号・口座番号）は未入力です。ダウンロード後に手動で補完してください。")
 
+@st.cache_data(show_spinner="PDF生成中...")
+def _cached_generate_statement(member_name, full_name, year, month, comp_tuple, reimb_csv):
+    """キャッシュ付きPDF生成（Streamlit再レンダリング時の再生成を防止）"""
+    comp = dict(zip(
+        ["qualification_adjusted_compensation", "withholding_tax", "dx_subsidy", "reimbursement", "payment"],
+        comp_tuple,
+    ))
+    reimb_df = pd.read_csv(io.StringIO(reimb_csv)) if reimb_csv else pd.DataFrame()
+    return generate_payment_statement(member_name, full_name, year, month, comp, reimb_df)
+
+
+@st.cache_data(show_spinner="ZIP生成中...")
+def _cached_generate_zip(comp_csv, reimb_csv, year, month):
+    """キャッシュ付きZIP生成"""
+    comp_df = pd.read_csv(io.StringIO(comp_csv))
+    reimb_df = pd.read_csv(io.StringIO(reimb_csv)) if reimb_csv else pd.DataFrame()
+    return generate_all_statements_zip(comp_df, reimb_df, year, month)
+
+
 with tab5:
     st.subheader("支払明細書")
     if not comp_loaded or df_comp.empty:
@@ -337,19 +359,22 @@ with tab5:
         if selected_stmt_member == "全メンバー":
             # 全メンバーサマリー
             st.caption(f"{len(comp_members):,} 名分の支払明細書を一括生成します")
-            zip_bytes = generate_all_statements_zip(
-                members_comp=df_comp,
-                reimbursement_df=df,
-                year=selected_year,
-                month=selected_month,
-            )
-            st.download_button(
-                "全メンバー一括ダウンロード (ZIP)",
-                zip_bytes,
-                file_name=f"payment_statements_{selected_year}_{selected_month:02d}.zip",
-                mime="application/zip",
-                key="wam_stmt_zip_download",
-            )
+            try:
+                zip_bytes = _cached_generate_zip(
+                    comp_csv=df_comp.to_csv(index=False),
+                    reimb_csv=df.to_csv(index=False) if not df.empty else "",
+                    year=selected_year,
+                    month=selected_month,
+                )
+                st.download_button(
+                    "全メンバー一括ダウンロード (ZIP)",
+                    zip_bytes,
+                    file_name=f"payment_statements_{selected_year}_{selected_month:02d}.zip",
+                    mime="application/zip",
+                    key="wam_stmt_zip_download",
+                )
+            except Exception as e:
+                st.error(f"ZIP生成に失敗しました: {e}")
         else:
             # 個別メンバー
             member_comp = df_comp[df_comp["nickname"] == selected_stmt_member].iloc[0]
@@ -378,23 +403,28 @@ with tab5:
             with cols5[2]:
                 render_kpi("合計 (A+B)", f"¥{subtotal_a + subtotal_b:,.0f}")
 
-            # PDF生成・ダウンロード
+            # PDF生成・ダウンロード（キャッシュ済み）
             full_name = str(member_comp.get("full_name", selected_stmt_member))
-            pdf_bytes = generate_payment_statement(
-                member_name=selected_stmt_member,
-                full_name=full_name,
-                year=selected_year,
-                month=selected_month,
-                compensation=comp_data,
-                reimbursement_items=member_reimb,
-            )
-            st.download_button(
-                "支払明細書PDFダウンロード",
-                pdf_bytes,
-                file_name=f"payment_statement_{selected_stmt_member}_{selected_year}_{selected_month:02d}.pdf",
-                mime="application/pdf",
-                key="wam_stmt_pdf_download",
-            )
+            comp_tuple = tuple(comp_data[k] for k in [
+                "qualification_adjusted_compensation", "withholding_tax",
+                "dx_subsidy", "reimbursement", "payment",
+            ])
+            reimb_csv = member_reimb.to_csv(index=False) if not member_reimb.empty else ""
+            try:
+                pdf_bytes = _cached_generate_statement(
+                    selected_stmt_member, full_name,
+                    selected_year, selected_month,
+                    comp_tuple, reimb_csv,
+                )
+                st.download_button(
+                    "支払明細書PDFダウンロード",
+                    pdf_bytes,
+                    file_name=f"payment_statement_{selected_stmt_member}_{selected_year}_{selected_month:02d}.pdf",
+                    mime="application/pdf",
+                    key="wam_stmt_pdf_download",
+                )
+            except Exception as e:
+                st.error(f"PDF生成に失敗しました: {e}")
 
             # 領収書URL一覧
             if not member_reimb.empty and "receipt_url" in member_reimb.columns:

--- a/dashboard/lib/receipt_pdf.py
+++ b/dashboard/lib/receipt_pdf.py
@@ -1,0 +1,280 @@
+"""支払明細書PDF生成モジュール
+
+メンバー×月ごとの支払明細書（業務委託費 + 立替経費）をPDFで出力する。
+WAM助成金の証拠書類として使用。
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import zipfile
+from pathlib import Path
+
+import pandas as pd
+from fpdf import FPDF
+
+logger = logging.getLogger(__name__)
+
+# --- フォント探索 ---
+_FONT_SEARCH_PATHS = [
+    # Docker (fonts-noto-cjk)
+    "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
+    # macOS
+    "/System/Library/Fonts/ヒラギノ角ゴシック W3.ttc",
+    "/System/Library/Fonts/ヒラギノ角ゴシック W4.ttc",
+    "/System/Library/Fonts/ヒラギノ角ゴシック W6.ttc",
+    "/Library/Fonts/Arial Unicode.ttf",
+]
+
+
+def _find_japanese_font() -> str | None:
+    """日本語フォントのパスを返す。見つからなければNone。"""
+    for p in _FONT_SEARCH_PATHS:
+        if Path(p).exists():
+            return p
+    return None
+
+
+# --- PDF生成 ---
+
+def _fmt_yen(amount: float) -> str:
+    """金額を ¥XX,XXX 形式にフォーマット"""
+    if amount < 0:
+        return f"-¥{abs(amount):,.0f}"
+    return f"¥{amount:,.0f}"
+
+
+class _StatementPDF(FPDF):
+    """支払明細書用のカスタムPDFクラス"""
+
+    def __init__(self):
+        super().__init__(orientation="P", unit="mm", format="A4")
+        self._has_jp_font = False
+        font_path = _find_japanese_font()
+        if font_path:
+            try:
+                self.add_font("jp", "", font_path)
+                self.add_font("jp", "B", font_path)
+                self._has_jp_font = True
+            except Exception:
+                logger.warning("日本語フォント読み込み失敗: %s", font_path)
+        self.add_page()
+        self.set_auto_page_break(auto=True, margin=15)
+
+    def _set_font(self, style: str = "", size: int = 10):
+        family = "jp" if self._has_jp_font else "Helvetica"
+        self.set_font(family, style, size)
+
+    def _draw_header(self, year: int, month: int):
+        self._set_font("B", 16)
+        self.cell(0, 12, "支 払 明 細 書", align="C", new_x="LMARGIN", new_y="NEXT")
+        self._set_font("", 11)
+        self.cell(0, 8, f"{year}年{month}月分", align="C", new_x="LMARGIN", new_y="NEXT")
+        self.ln(4)
+
+    def _draw_member_info(self, full_name: str, member_name: str):
+        self._set_font("", 11)
+        label = full_name if full_name and full_name != member_name else member_name
+        if full_name and full_name != member_name:
+            label += f" ({member_name})"
+        self.cell(0, 8, f"支払先: {label}", new_x="LMARGIN", new_y="NEXT")
+        self.ln(2)
+
+    def _draw_section_title(self, title: str):
+        self._set_font("B", 11)
+        self.set_fill_color(230, 230, 230)
+        self.cell(0, 8, title, fill=True, new_x="LMARGIN", new_y="NEXT")
+        self._set_font("", 10)
+
+    def _draw_compensation(self, comp: dict) -> float:
+        """業務委託費セクションを描画し、小計(A)を返す"""
+        self._draw_section_title("1. 業務委託費")
+        self.ln(2)
+
+        rows = [
+            ("報酬額", comp.get("qualification_adjusted_compensation", 0)),
+            ("源泉徴収", comp.get("withholding_tax", 0)),
+            ("DX補助", comp.get("dx_subsidy", 0)),
+        ]
+        subtotal_a = sum(v for _, v in rows)
+        for label, val in rows:
+            self.cell(80, 7, f"  {label}", new_x="RIGHT")
+            self.cell(60, 7, _fmt_yen(val), align="R", new_x="LMARGIN", new_y="NEXT")
+
+        self.ln(1)
+        self._set_font("B", 10)
+        self.cell(80, 7, "  小計 (A)", new_x="RIGHT")
+        self.cell(60, 7, _fmt_yen(subtotal_a), align="R", new_x="LMARGIN", new_y="NEXT")
+        self._set_font("", 10)
+        self.ln(4)
+        return subtotal_a
+
+    def _draw_reimbursement(self, items: pd.DataFrame) -> float:
+        """旅費・立替経費セクションを描画し、小計(B)を返す"""
+        self._draw_section_title("2. 旅費・立替経費")
+        self.ln(2)
+
+        if items.empty:
+            self.cell(0, 7, "  (該当なし)", new_x="LMARGIN", new_y="NEXT")
+            self.ln(4)
+            return 0.0
+
+        # テーブルヘッダー
+        col_widths = [22, 30, 40, 35, 25, 18]
+        headers = ["月日", "対象PJ", "支払用途", "分類", "金額", "領収書"]
+        self._set_font("B", 9)
+        for i, (w, h) in enumerate(zip(col_widths, headers)):
+            last = i == len(headers) - 1
+            self.cell(w, 6, h, border="B",
+                      new_x="LMARGIN" if last else "RIGHT",
+                      new_y="NEXT" if last else "TOP")
+        self._set_font("", 9)
+
+        # テーブル行
+        subtotal_b = 0.0
+        for _, row in items.iterrows():
+            amount = float(row.get("payment_amount_numeric", 0) or 0)
+            subtotal_b += amount
+            receipt = row.get("receipt_url", "")
+            has_receipt = bool(receipt and str(receipt).strip())
+
+            vals = [
+                str(row.get("date", "")),
+                str(row.get("target_project", ""))[:8],
+                str(row.get("payment_purpose", ""))[:12],
+                str(row.get("category", ""))[:8],
+                _fmt_yen(amount),
+                "○" if has_receipt else "-",
+            ]
+            for i, (w, v) in enumerate(zip(col_widths, vals)):
+                align = "R" if i == 4 else "L"
+                last = i == len(vals) - 1
+                self.cell(w, 6, v, align=align,
+                          new_x="LMARGIN" if last else "RIGHT",
+                          new_y="NEXT" if last else "TOP")
+
+        self.ln(1)
+        self._set_font("B", 10)
+        self.cell(80, 7, "  小計 (B)", new_x="RIGHT")
+        self.cell(60, 7, _fmt_yen(subtotal_b), align="R", new_x="LMARGIN", new_y="NEXT")
+        self._set_font("", 10)
+        self.ln(4)
+        return subtotal_b
+
+    def _draw_total(self, total: float):
+        self.set_draw_color(0, 0, 0)
+        self.line(10, self.get_y(), 200, self.get_y())
+        self.ln(2)
+        self._set_font("B", 12)
+        self.cell(80, 10, "合計支払額 (A+B)", new_x="RIGHT")
+        self.cell(60, 10, _fmt_yen(total), align="R", new_x="LMARGIN", new_y="NEXT")
+        self.line(10, self.get_y(), 200, self.get_y())
+        self._set_font("", 10)
+        self.ln(6)
+
+    def _draw_receipt_urls(self, items: pd.DataFrame):
+        urls = []
+        if not items.empty and "receipt_url" in items.columns:
+            for url in items["receipt_url"]:
+                if url and str(url).strip():
+                    urls.append(str(url).strip())
+        if not urls:
+            return
+
+        self._set_font("B", 10)
+        self.cell(0, 7, "添付書類一覧", new_x="LMARGIN", new_y="NEXT")
+        self._set_font("", 8)
+        for i, url in enumerate(urls, 1):
+            display = url if len(url) <= 70 else url[:67] + "..."
+            self.cell(0, 5, f"  {i}. {display}", new_x="LMARGIN", new_y="NEXT")
+
+
+def generate_payment_statement(
+    member_name: str,
+    full_name: str,
+    year: int,
+    month: int,
+    compensation: dict,
+    reimbursement_items: pd.DataFrame,
+) -> bytes:
+    """1メンバー×1月の支払明細書PDFを生成
+
+    Args:
+        member_name: ニックネーム
+        full_name: 本名
+        year: 対象年
+        month: 対象月
+        compensation: 報酬データ dict
+            - qualification_adjusted_compensation: 報酬額
+            - withholding_tax: 源泉徴収
+            - dx_subsidy: DX補助
+            - reimbursement: 立替合計（参考値）
+            - payment: 支払額
+        reimbursement_items: 立替明細 DataFrame
+            - date, target_project, category, payment_purpose,
+              payment_amount_numeric, receipt_url
+
+    Returns:
+        PDF bytes
+    """
+    pdf = _StatementPDF()
+    pdf._draw_header(year, month)
+    pdf._draw_member_info(full_name, member_name)
+    subtotal_a = pdf._draw_compensation(compensation)
+    subtotal_b = pdf._draw_reimbursement(reimbursement_items)
+    pdf._draw_total(subtotal_a + subtotal_b)
+    pdf._draw_receipt_urls(reimbursement_items)
+
+    return bytes(pdf.output())
+
+
+def generate_all_statements_zip(
+    members_comp: pd.DataFrame,
+    reimbursement_df: pd.DataFrame,
+    year: int,
+    month: int,
+) -> bytes:
+    """全メンバーの支払明細書PDFをZIPにまとめる
+
+    Args:
+        members_comp: 報酬データ（年月フィルタ済み）
+        reimbursement_df: 立替明細（年月フィルタ済み）
+        year: 対象年
+        month: 対象月
+
+    Returns:
+        ZIP bytes
+    """
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for _, row in members_comp.iterrows():
+            nickname = str(row.get("nickname", ""))
+            full_name = str(row.get("full_name", nickname))
+            comp = {
+                "qualification_adjusted_compensation": float(
+                    row.get("qualification_adjusted_compensation", 0) or 0
+                ),
+                "withholding_tax": float(row.get("withholding_tax", 0) or 0),
+                "dx_subsidy": float(row.get("dx_subsidy", 0) or 0),
+                "reimbursement": float(row.get("reimbursement", 0) or 0),
+                "payment": float(row.get("payment", 0) or 0),
+            }
+            # メンバーの立替明細を抽出
+            member_reimb = reimbursement_df[
+                reimbursement_df["nickname"] == nickname
+            ] if not reimbursement_df.empty else pd.DataFrame()
+
+            pdf_bytes = generate_payment_statement(
+                member_name=nickname,
+                full_name=full_name,
+                year=year,
+                month=month,
+                compensation=comp,
+                reimbursement_items=member_reimb,
+            )
+            safe_name = nickname.replace("/", "_").replace("\\", "_")
+            filename = f"{safe_name}_{year}_{month:02d}.pdf"
+            zf.writestr(filename, pdf_bytes)
+
+    return buf.getvalue()

--- a/dashboard/lib/receipt_pdf.py
+++ b/dashboard/lib/receipt_pdf.py
@@ -27,6 +27,16 @@ _FONT_SEARCH_PATHS = [
     "/Library/Fonts/Arial Unicode.ttf",
 ]
 
+# 立替明細テーブルの列定義: (幅mm, ヘッダー, align)
+_REIMB_COLUMNS = [
+    (22, "月日", "L"),
+    (30, "対象PJ", "L"),
+    (40, "支払用途", "L"),
+    (35, "分類", "L"),
+    (25, "金額", "R"),
+    (18, "領収書", "L"),
+]
+
 
 def _find_japanese_font() -> str | None:
     """日本語フォントのパスを返す。見つからなければNone。"""
@@ -55,37 +65,37 @@ class _StatementPDF(FPDF):
         if font_path:
             try:
                 self.add_font("jp", "", font_path)
-                self.add_font("jp", "B", font_path)
                 self._has_jp_font = True
-            except Exception:
-                logger.warning("日本語フォント読み込み失敗: %s", font_path)
+            except (OSError, RuntimeError) as exc:
+                logger.error("日本語フォント読み込み失敗: %s (%s)", font_path, exc)
+        else:
+            logger.warning("日本語フォントが見つかりません（Helveticaフォールバック）")
         self.add_page()
         self.set_auto_page_break(auto=True, margin=15)
 
-    def _set_font(self, style: str = "", size: int = 10):
+    def _set_font(self, size: int = 10):
         family = "jp" if self._has_jp_font else "Helvetica"
-        self.set_font(family, style, size)
+        self.set_font(family, "", size)
 
     def _draw_header(self, year: int, month: int):
-        self._set_font("B", 16)
+        self._set_font(16)
         self.cell(0, 12, "支 払 明 細 書", align="C", new_x="LMARGIN", new_y="NEXT")
-        self._set_font("", 11)
+        self._set_font(11)
         self.cell(0, 8, f"{year}年{month}月分", align="C", new_x="LMARGIN", new_y="NEXT")
         self.ln(4)
 
     def _draw_member_info(self, full_name: str, member_name: str):
-        self._set_font("", 11)
-        label = full_name if full_name and full_name != member_name else member_name
-        if full_name and full_name != member_name:
-            label += f" ({member_name})"
+        self._set_font(11)
+        has_full = full_name and full_name != member_name
+        label = f"{full_name} ({member_name})" if has_full else member_name
         self.cell(0, 8, f"支払先: {label}", new_x="LMARGIN", new_y="NEXT")
         self.ln(2)
 
     def _draw_section_title(self, title: str):
-        self._set_font("B", 11)
+        self._set_font(12)
         self.set_fill_color(230, 230, 230)
         self.cell(0, 8, title, fill=True, new_x="LMARGIN", new_y="NEXT")
-        self._set_font("", 10)
+        self._set_font(10)
 
     def _draw_compensation(self, comp: dict) -> float:
         """業務委託費セクションを描画し、小計(A)を返す"""
@@ -103,10 +113,10 @@ class _StatementPDF(FPDF):
             self.cell(60, 7, _fmt_yen(val), align="R", new_x="LMARGIN", new_y="NEXT")
 
         self.ln(1)
-        self._set_font("B", 10)
+        self._set_font(11)
         self.cell(80, 7, "  小計 (A)", new_x="RIGHT")
         self.cell(60, 7, _fmt_yen(subtotal_a), align="R", new_x="LMARGIN", new_y="NEXT")
-        self._set_font("", 10)
+        self._set_font(10)
         self.ln(4)
         return subtotal_a
 
@@ -121,15 +131,12 @@ class _StatementPDF(FPDF):
             return 0.0
 
         # テーブルヘッダー
-        col_widths = [22, 30, 40, 35, 25, 18]
-        headers = ["月日", "対象PJ", "支払用途", "分類", "金額", "領収書"]
-        self._set_font("B", 9)
-        for i, (w, h) in enumerate(zip(col_widths, headers)):
-            last = i == len(headers) - 1
+        self._set_font(9)
+        for i, (w, h, _) in enumerate(_REIMB_COLUMNS):
+            last = i == len(_REIMB_COLUMNS) - 1
             self.cell(w, 6, h, border="B",
                       new_x="LMARGIN" if last else "RIGHT",
                       new_y="NEXT" if last else "TOP")
-        self._set_font("", 9)
 
         # テーブル行
         subtotal_b = 0.0
@@ -147,30 +154,31 @@ class _StatementPDF(FPDF):
                 _fmt_yen(amount),
                 "○" if has_receipt else "-",
             ]
-            for i, (w, v) in enumerate(zip(col_widths, vals)):
-                align = "R" if i == 4 else "L"
+            for i, ((w, _, align), v) in enumerate(zip(_REIMB_COLUMNS, vals)):
                 last = i == len(vals) - 1
                 self.cell(w, 6, v, align=align,
                           new_x="LMARGIN" if last else "RIGHT",
                           new_y="NEXT" if last else "TOP")
 
         self.ln(1)
-        self._set_font("B", 10)
+        self._set_font(11)
         self.cell(80, 7, "  小計 (B)", new_x="RIGHT")
         self.cell(60, 7, _fmt_yen(subtotal_b), align="R", new_x="LMARGIN", new_y="NEXT")
-        self._set_font("", 10)
+        self._set_font(10)
         self.ln(4)
         return subtotal_b
 
     def _draw_total(self, total: float):
         self.set_draw_color(0, 0, 0)
-        self.line(10, self.get_y(), 200, self.get_y())
+        x_left = self.l_margin
+        x_right = self.w - self.r_margin
+        self.line(x_left, self.get_y(), x_right, self.get_y())
         self.ln(2)
-        self._set_font("B", 12)
+        self._set_font(13)
         self.cell(80, 10, "合計支払額 (A+B)", new_x="RIGHT")
         self.cell(60, 10, _fmt_yen(total), align="R", new_x="LMARGIN", new_y="NEXT")
-        self.line(10, self.get_y(), 200, self.get_y())
-        self._set_font("", 10)
+        self.line(x_left, self.get_y(), x_right, self.get_y())
+        self._set_font(10)
         self.ln(6)
 
     def _draw_receipt_urls(self, items: pd.DataFrame):
@@ -182,9 +190,9 @@ class _StatementPDF(FPDF):
         if not urls:
             return
 
-        self._set_font("B", 10)
+        self._set_font(10)
         self.cell(0, 7, "添付書類一覧", new_x="LMARGIN", new_y="NEXT")
-        self._set_font("", 8)
+        self._set_font(8)
         for i, url in enumerate(urls, 1):
             display = url if len(url) <= 70 else url[:67] + "..."
             self.cell(0, 5, f"  {i}. {display}", new_x="LMARGIN", new_y="NEXT")
@@ -209,8 +217,8 @@ def generate_payment_statement(
             - qualification_adjusted_compensation: 報酬額
             - withholding_tax: 源泉徴収
             - dx_subsidy: DX補助
-            - reimbursement: 立替合計（参考値）
-            - payment: 支払額
+            - reimbursement: 立替合計（PDF未使用、ZIP生成時の参考値）
+            - payment: 支払額（PDF未使用、ZIP生成時の参考値）
         reimbursement_items: 立替明細 DataFrame
             - date, target_project, category, payment_purpose,
               payment_amount_numeric, receipt_url
@@ -239,7 +247,11 @@ def generate_all_statements_zip(
 
     Args:
         members_comp: 報酬データ（年月フィルタ済み）
+            必須カラム: nickname, full_name, qualification_adjusted_compensation,
+            withholding_tax, dx_subsidy, reimbursement, payment
         reimbursement_df: 立替明細（年月フィルタ済み）
+            必須カラム: nickname, date, target_project, category,
+            payment_purpose, payment_amount_numeric, receipt_url
         year: 対象年
         month: 対象月
 
@@ -247,34 +259,47 @@ def generate_all_statements_zip(
         ZIP bytes
     """
     buf = io.BytesIO()
+    errors: list[str] = []
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
         for _, row in members_comp.iterrows():
             nickname = str(row.get("nickname", ""))
-            full_name = str(row.get("full_name", nickname))
-            comp = {
-                "qualification_adjusted_compensation": float(
-                    row.get("qualification_adjusted_compensation", 0) or 0
-                ),
-                "withholding_tax": float(row.get("withholding_tax", 0) or 0),
-                "dx_subsidy": float(row.get("dx_subsidy", 0) or 0),
-                "reimbursement": float(row.get("reimbursement", 0) or 0),
-                "payment": float(row.get("payment", 0) or 0),
-            }
-            # メンバーの立替明細を抽出
-            member_reimb = reimbursement_df[
-                reimbursement_df["nickname"] == nickname
-            ] if not reimbursement_df.empty else pd.DataFrame()
+            try:
+                full_name = str(row.get("full_name", nickname))
+                comp = {
+                    "qualification_adjusted_compensation": float(
+                        row.get("qualification_adjusted_compensation", 0) or 0
+                    ),
+                    "withholding_tax": float(row.get("withholding_tax", 0) or 0),
+                    "dx_subsidy": float(row.get("dx_subsidy", 0) or 0),
+                    "reimbursement": float(row.get("reimbursement", 0) or 0),
+                    "payment": float(row.get("payment", 0) or 0),
+                }
+                # メンバーの立替明細を抽出
+                if not reimbursement_df.empty and "nickname" in reimbursement_df.columns:
+                    member_reimb = reimbursement_df[
+                        reimbursement_df["nickname"] == nickname
+                    ]
+                else:
+                    member_reimb = pd.DataFrame()
 
-            pdf_bytes = generate_payment_statement(
-                member_name=nickname,
-                full_name=full_name,
-                year=year,
-                month=month,
-                compensation=comp,
-                reimbursement_items=member_reimb,
-            )
-            safe_name = nickname.replace("/", "_").replace("\\", "_")
-            filename = f"{safe_name}_{year}_{month:02d}.pdf"
-            zf.writestr(filename, pdf_bytes)
+                pdf_bytes = generate_payment_statement(
+                    member_name=nickname,
+                    full_name=full_name,
+                    year=year,
+                    month=month,
+                    compensation=comp,
+                    reimbursement_items=member_reimb,
+                )
+                safe_name = nickname.replace("/", "_").replace("\\", "_")
+                filename = f"{safe_name}_{year}_{month:02d}.pdf"
+                zf.writestr(filename, pdf_bytes)
+            except Exception as e:
+                logger.error("PDF生成失敗 (member=%s): %s", nickname, e, exc_info=True)
+                errors.append(f"{nickname}: {e}")
+
+        if errors:
+            error_report = "PDF生成エラー:\n" + "\n".join(errors)
+            zf.writestr("_errors.txt", error_report)
+            logger.warning("%d件のPDF生成に失敗", len(errors))
 
     return buf.getvalue()

--- a/dashboard/requirements.txt
+++ b/dashboard/requirements.txt
@@ -6,3 +6,4 @@ pandas==2.2.3
 pyarrow==18.1.0
 db-dtypes==1.3.1
 requests>=2.32.0
+fpdf2>=2.8.1

--- a/dashboard/tests/test_receipt_pdf.py
+++ b/dashboard/tests/test_receipt_pdf.py
@@ -1,0 +1,236 @@
+"""Unit tests for lib/receipt_pdf.py
+
+支払明細書PDF生成ロジックのテスト。
+フォントなし環境ではHelveticaフォールバック（日本語は文字化け、構造テストは通る）。
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+
+import pandas as pd
+import pytest
+
+from lib.receipt_pdf import (
+    generate_all_statements_zip,
+    generate_payment_statement,
+)
+
+
+# --- Fixtures ---
+
+@pytest.fixture
+def compensation():
+    return {
+        "qualification_adjusted_compensation": 100000.0,
+        "withholding_tax": -10210.0,
+        "dx_subsidy": 0.0,
+        "reimbursement": 15000.0,
+        "payment": 104790.0,
+    }
+
+
+@pytest.fixture
+def reimbursement_items():
+    return pd.DataFrame({
+        "date": ["3月20日", "3月22日"],
+        "target_project": ["ケアプーPJ", "経産省PJ"],
+        "category": ["旅費交通費", "個人立替費"],
+        "payment_purpose": ["新幹線代", "宿泊費"],
+        "payment_amount_numeric": [10000.0, 5000.0],
+        "receipt_url": ["https://drive.google.com/file/d/abc", ""],
+    })
+
+
+@pytest.fixture
+def comp_df_multi():
+    return pd.DataFrame({
+        "year": [2026, 2026],
+        "month": [4, 4],
+        "nickname": ["太郎", "花子"],
+        "full_name": ["山田太郎", "鈴木花子"],
+        "qualification_adjusted_compensation": [100000.0, 50000.0],
+        "withholding_tax": [-10210.0, -5105.0],
+        "dx_subsidy": [0.0, 5000.0],
+        "reimbursement": [15000.0, 0.0],
+        "payment": [104790.0, 49895.0],
+    })
+
+
+@pytest.fixture
+def reimb_df_multi():
+    return pd.DataFrame({
+        "nickname": ["太郎", "太郎", "花子"],
+        "normalized_year": [2026, 2026, 2026],
+        "month": [4, 4, 4],
+        "date": ["3月20日", "3月22日", "4月1日"],
+        "target_project": ["ケアプーPJ", "経産省PJ", "神奈川県PJ"],
+        "category": ["旅費交通費", "個人立替費", "旅費交通費"],
+        "payment_purpose": ["新幹線代", "宿泊費", "バス代"],
+        "payment_amount_numeric": [10000.0, 5000.0, 3000.0],
+        "receipt_url": ["https://drive.google.com/1", "", "https://drive.google.com/3"],
+    })
+
+
+# --- generate_payment_statement ---
+
+class TestGeneratePaymentStatement:
+    def test_returns_bytes(self, compensation, reimbursement_items):
+        result = generate_payment_statement(
+            member_name="太郎",
+            full_name="山田太郎",
+            year=2026,
+            month=4,
+            compensation=compensation,
+            reimbursement_items=reimbursement_items,
+        )
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+
+    def test_pdf_header(self, compensation, reimbursement_items):
+        result = generate_payment_statement(
+            member_name="太郎",
+            full_name="山田太郎",
+            year=2026,
+            month=4,
+            compensation=compensation,
+            reimbursement_items=reimbursement_items,
+        )
+        assert result[:5] == b"%PDF-"
+
+    def test_empty_reimbursement(self, compensation):
+        empty_items = pd.DataFrame(columns=[
+            "date", "target_project", "category", "payment_purpose",
+            "payment_amount_numeric", "receipt_url",
+        ])
+        result = generate_payment_statement(
+            member_name="太郎",
+            full_name="山田太郎",
+            year=2026,
+            month=4,
+            compensation=compensation,
+            reimbursement_items=empty_items,
+        )
+        assert isinstance(result, bytes)
+        assert result[:5] == b"%PDF-"
+
+    def test_zero_compensation(self, reimbursement_items):
+        zero_comp = {
+            "qualification_adjusted_compensation": 0.0,
+            "withholding_tax": 0.0,
+            "dx_subsidy": 0.0,
+            "reimbursement": 15000.0,
+            "payment": 15000.0,
+        }
+        result = generate_payment_statement(
+            member_name="太郎",
+            full_name="山田太郎",
+            year=2026,
+            month=4,
+            compensation=zero_comp,
+            reimbursement_items=reimbursement_items,
+        )
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+
+    def test_missing_receipt_urls(self, compensation):
+        items = pd.DataFrame({
+            "date": ["3月20日"],
+            "target_project": ["ケアプーPJ"],
+            "category": ["旅費交通費"],
+            "payment_purpose": ["新幹線代"],
+            "payment_amount_numeric": [10000.0],
+            "receipt_url": [None],
+        })
+        result = generate_payment_statement(
+            member_name="太郎",
+            full_name="山田太郎",
+            year=2026,
+            month=4,
+            compensation=compensation,
+            reimbursement_items=items,
+        )
+        assert isinstance(result, bytes)
+
+
+# --- generate_all_statements_zip ---
+
+class TestGenerateAllStatementsZip:
+    def test_returns_valid_zip(self, comp_df_multi, reimb_df_multi):
+        result = generate_all_statements_zip(
+            members_comp=comp_df_multi,
+            reimbursement_df=reimb_df_multi,
+            year=2026,
+            month=4,
+        )
+        assert isinstance(result, bytes)
+        zf = zipfile.ZipFile(io.BytesIO(result))
+        assert len(zf.namelist()) == 2  # 太郎 + 花子
+
+    def test_zip_file_names(self, comp_df_multi, reimb_df_multi):
+        result = generate_all_statements_zip(
+            members_comp=comp_df_multi,
+            reimbursement_df=reimb_df_multi,
+            year=2026,
+            month=4,
+        )
+        zf = zipfile.ZipFile(io.BytesIO(result))
+        names = sorted(zf.namelist())
+        assert all(name.endswith(".pdf") for name in names)
+        assert all("2026_04" in name for name in names)
+
+    def test_empty_comp_returns_empty_zip(self):
+        empty_comp = pd.DataFrame(columns=[
+            "year", "month", "nickname", "full_name",
+            "qualification_adjusted_compensation", "withholding_tax",
+            "dx_subsidy", "reimbursement", "payment",
+        ])
+        empty_reimb = pd.DataFrame(columns=[
+            "nickname", "normalized_year", "month", "date",
+            "target_project", "category", "payment_purpose",
+            "payment_amount_numeric", "receipt_url",
+        ])
+        result = generate_all_statements_zip(
+            members_comp=empty_comp,
+            reimbursement_df=empty_reimb,
+            year=2026,
+            month=4,
+        )
+        assert isinstance(result, bytes)
+        zf = zipfile.ZipFile(io.BytesIO(result))
+        assert len(zf.namelist()) == 0
+
+    def test_member_without_reimbursement(self, comp_df_multi):
+        # 花子には立替明細なし
+        reimb_only_taro = pd.DataFrame({
+            "nickname": ["太郎", "太郎"],
+            "normalized_year": [2026, 2026],
+            "month": [4, 4],
+            "date": ["3月20日", "3月22日"],
+            "target_project": ["ケアプーPJ", "経産省PJ"],
+            "category": ["旅費交通費", "個人立替費"],
+            "payment_purpose": ["新幹線代", "宿泊費"],
+            "payment_amount_numeric": [10000.0, 5000.0],
+            "receipt_url": ["https://a.com", ""],
+        })
+        result = generate_all_statements_zip(
+            members_comp=comp_df_multi,
+            reimbursement_df=reimb_only_taro,
+            year=2026,
+            month=4,
+        )
+        zf = zipfile.ZipFile(io.BytesIO(result))
+        assert len(zf.namelist()) == 2  # 花子も空明細で生成される
+
+    def test_each_pdf_is_valid(self, comp_df_multi, reimb_df_multi):
+        result = generate_all_statements_zip(
+            members_comp=comp_df_multi,
+            reimbursement_df=reimb_df_multi,
+            year=2026,
+            month=4,
+        )
+        zf = zipfile.ZipFile(io.BytesIO(result))
+        for name in zf.namelist():
+            pdf_bytes = zf.read(name)
+            assert pdf_bytes[:5] == b"%PDF-"

--- a/dashboard/tests/test_receipt_pdf.py
+++ b/dashboard/tests/test_receipt_pdf.py
@@ -13,6 +13,7 @@ import pandas as pd
 import pytest
 
 from lib.receipt_pdf import (
+    _fmt_yen,
     generate_all_statements_zip,
     generate_payment_statement,
 )
@@ -71,6 +72,22 @@ def reimb_df_multi():
         "payment_amount_numeric": [10000.0, 5000.0, 3000.0],
         "receipt_url": ["https://drive.google.com/1", "", "https://drive.google.com/3"],
     })
+
+
+# --- _fmt_yen ---
+
+class TestFmtYen:
+    def test_positive(self):
+        assert _fmt_yen(10000.0) == "¥10,000"
+
+    def test_negative(self):
+        assert _fmt_yen(-10210.0) == "-¥10,210"
+
+    def test_zero(self):
+        assert _fmt_yen(0.0) == "¥0"
+
+    def test_large(self):
+        assert _fmt_yen(1234567.0) == "¥1,234,567"
 
 
 # --- generate_payment_statement ---


### PR DESCRIPTION
## Summary
- WAM立替金確認ページに Tab 5「支払明細書」を追加
- `fpdf2` による支払明細書PDF生成（業務委託費A + 立替経費B の合算）
- 個別メンバーPDFダウンロード + 全メンバーZIP一括ダウンロード
- Dockerfile に `fonts-noto-cjk` 追加（日本語PDF対応）
- テスト10件追加（Dashboard 231 + Cloud Run 42 = 273 PASS）

## 変更ファイル
| ファイル | 変更 |
|---------|------|
| `dashboard/lib/receipt_pdf.py` | **新規** PDF生成ロジック |
| `dashboard/_pages/wam_monthly.py` | Tab 5 追加 |
| `dashboard/requirements.txt` | `fpdf2>=2.8.1` 追加 |
| `dashboard/Dockerfile` | 日本語フォント追加 |
| `dashboard/tests/test_receipt_pdf.py` | **新規** 10テスト |
| `CLAUDE.md` | テスト件数更新 |

## 設計判断
- 口座情報同様、receipt_url の実ファイルダウンロード・バンドルは Phase B（Drive API必要）
- Tab 5 新設（Tab 4 の報酬/振込CSVとは別ワークフロー）
- フォントなし環境（テスト）ではHelveticaフォールバック

## Test plan
- [x] `python3 -m pytest dashboard/tests/ -q` — 231 PASS
- [x] `python3 -m pytest cloud-run/tests/ -q` — 42 PASS
- [ ] デプロイ後 Playwright で Tab 5 動作確認
- [ ] PDFダウンロード → 内容確認（日本語表示・金額正確性）

🤖 Generated with [Claude Code](https://claude.com/claude-code)