### PR TITLE
fix: PDF日本語フォントをIPAゴシック(TTF)に変更 — TTC文字化け解消

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -8,10 +8,11 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # 日本語フォント（支払明細書PDF生成用）
+# fonts-ipafont-gothic: 単体TTFファイル（TTC由来のグリフ文字化けを回避）
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends fonts-noto-cjk && \
+    apt-get install -y --no-install-recommends fonts-ipafont-gothic && \
     rm -rf /var/lib/apt/lists/* && \
-    ls /usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc > /dev/null
+    ls /usr/share/fonts/opentype/ipafont-gothic/ipag.ttf > /dev/null
 
 # Google翻訳を無効化: StreamlitのHTMLテンプレートにtranslate="no"を埋め込む
 RUN sed -i 's|<html|<html translate="no" lang="ja"|' \

--- a/dashboard/lib/receipt_pdf.py
+++ b/dashboard/lib/receipt_pdf.py
@@ -18,8 +18,8 @@ logger = logging.getLogger(__name__)
 
 # --- フォント探索 ---
 _FONT_SEARCH_PATHS = [
-    # Docker (fonts-noto-cjk)
-    "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
+    # Docker (fonts-ipafont-gothic) — 単体TTF、TTC由来の文字化けなし
+    "/usr/share/fonts/opentype/ipafont-gothic/ipag.ttf",
     # macOS
     "/System/Library/Fonts/ヒラギノ角ゴシック W3.ttc",
     "/System/Library/Fonts/ヒラギノ角ゴシック W4.ttc",


### PR DESCRIPTION
## Summary
- NotoSansCJK-Regular.ttc (TTC) でfpdf2がindex 0(簡体字)を使用し、支払明細書PDFが文字化けしていた
- 単体TTFのIPAゴシック(`fonts-ipafont-gothic`)に変更し日本語レンダリングを正常化
- Dockerfile: `fonts-noto-cjk` → `fonts-ipafont-gothic`

## Test plan
- [x] Dashboard 235テスト全PASS
- [x] Cloud Run 42テスト全PASS
- [x] Cloud Run デプロイ (rev 00227-h6b)
- [x] Playwright: Tab 5 → Akana選択 → PDFダウンロード → 日本語正常表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)