### PR TITLE
feat: タダメンMマスタ全量収集 — member_masterテーブル追加

### DIFF
--- a/cloud-run/config.py
+++ b/cloud-run/config.py
@@ -13,6 +13,7 @@ BQ_TABLE_MEMBERS = "members"
 BQ_TABLE_GROUPS_MASTER = "groups_master"
 BQ_TABLE_REIMBURSEMENT = "reimbursement_items"
 BQ_TABLE_WAM_PROJECTS = "wam_target_projects"
+BQ_TABLE_MEMBER_MASTER = "member_master"
 
 # 管理表スプレッドシート
 MASTER_SPREADSHEET_ID = "1fBNfkFBARSpT-OpLOytbAfoa0Xo5LTWv7irimssxcUU"
@@ -27,6 +28,49 @@ GAS_SPREADSHEET_ID = "16V9fs2kf2IzxdVz1GOJHY9mR1MmGjbmwm5L0ECiMLrc"
 MEMBER_SPREADSHEET_ID = MASTER_SPREADSHEET_ID  # 管理表に完全データあり
 MEMBER_SHEET_NAME = "報告シート（「説明用」以外はタダメンMから関数生成）M"
 MEMBER_START_ROW = 2  # 1行目はヘッダー
+
+# タダメンMマスタ全量取得（タダメンMタブから口座・住所等を含む全有用データ）
+MEMBER_MASTER_SHEET_NAME = "タダメンM"
+MEMBER_MASTER_START_ROW = 2
+# タダメンMタブの列インデックス(0-based) → member_masterカラムへのマッピング
+MEMBER_MASTER_COLUMN_INDICES = [
+    0,   # A: member_id
+    1,   # B: last_name
+    2,   # C: first_name
+    3,   # D: last_name_kana
+    4,   # E: first_name_kana
+    5,   # F: nickname
+    8,   # I: email
+    9,   # J: postal_code
+    10,  # K: prefecture
+    11,  # L: address
+    14,  # O: gws_account
+    15,  # P: report_url_1
+    16,  # Q: report_url_2
+    19,  # T: shipping_postal_code
+    20,  # U: shipping_address
+    29,  # AD: qualification_allowance
+    30,  # AE: position_rate
+    31,  # AF: corporate_sheet
+    32,  # AG: donation_sheet
+    33,  # AH: qualification_sheet
+    34,  # AI: bank1_type
+    35,  # AJ: bank1_name
+    36,  # AK: bank1_code
+    37,  # AL: bank1_branch_name
+    38,  # AM: bank1_branch_code
+    39,  # AN: bank1_account_number
+    40,  # AO: bank1_deposit_type
+    41,  # AP: bank1_holder_name
+    42,  # AQ: bank2_type
+    43,  # AR: bank2_name
+    44,  # AS: bank2_code
+    45,  # AT: bank2_branch_name
+    46,  # AU: bank2_branch_code
+    47,  # AV: bank2_account_number
+    48,  # AW: bank2_deposit_type
+    49,  # AX: bank2_holder_name
+]
 
 # スキップ対象URL
 SKIP_URLS = [
@@ -103,5 +147,20 @@ TABLE_COLUMNS = {
     ],
     BQ_TABLE_WAM_PROJECTS: [
         "target_project", "wam_flag", "note",
+    ],
+    BQ_TABLE_MEMBER_MASTER: [
+        "member_id", "last_name", "first_name",
+        "last_name_kana", "first_name_kana", "nickname",
+        "email", "postal_code", "prefecture", "address",
+        "gws_account", "report_url_1", "report_url_2",
+        "shipping_postal_code", "shipping_address",
+        "qualification_allowance", "position_rate",
+        "corporate_sheet", "donation_sheet", "qualification_sheet",
+        "bank1_type", "bank1_name", "bank1_code",
+        "bank1_branch_name", "bank1_branch_code",
+        "bank1_account_number", "bank1_deposit_type", "bank1_holder_name",
+        "bank2_type", "bank2_name", "bank2_code",
+        "bank2_branch_name", "bank2_branch_code",
+        "bank2_account_number", "bank2_deposit_type", "bank2_holder_name",
     ],
 }

--- a/cloud-run/main.py
+++ b/cloud-run/main.py
@@ -89,6 +89,24 @@ def run_consolidation():
                 "立替金シート収集スキップ（本体処理は完了）: %s", reimb_err, exc_info=True
             )
 
+        # Step 7: タダメンMマスタ全量取得（失敗しても本体は成功扱い）
+        try:
+            logger.info("--- タダメンMマスタ収集開始 ---")
+            service = sheets_collector._build_sheets_service()
+            member_master_data = sheets_collector.collect_member_master(service)
+            member_master_count = bq_loader.load_to_bigquery(
+                bq_loader.config.BQ_TABLE_MEMBER_MASTER, member_master_data
+            )
+            results[bq_loader.config.BQ_TABLE_MEMBER_MASTER] = member_master_count
+            logger.info(
+                "--- タダメンMマスタ収集完了 (member_master: %d) ---",
+                member_master_count,
+            )
+        except Exception as mm_err:
+            logger.warning(
+                "タダメンMマスタ収集スキップ（本体処理は完了）: %s", mm_err, exc_info=True
+            )
+
         elapsed = round(time.time() - start, 1)
         summary = {
             "status": "success",

--- a/cloud-run/sheets_collector.py
+++ b/cloud-run/sheets_collector.py
@@ -349,6 +349,44 @@ def collect_members(service) -> list[list]:
     return filtered
 
 
+def collect_member_master(service) -> list[list]:
+    """タダメンMタブから全有用データを取得
+
+    A:AX列を一括取得し、MEMBER_MASTER_COLUMN_INDICESで指定された列のみ抽出。
+    口座情報・住所・姓名等を含む。A列(member_id)が空の行はスキップ。
+    """
+    sheet = service.spreadsheets()
+    range_notation = (
+        f"'{config.MEMBER_MASTER_SHEET_NAME}'"
+        f"!A{config.MEMBER_MASTER_START_ROW}:AX"
+    )
+
+    try:
+        request = sheet.values().get(
+            spreadsheetId=config.MEMBER_SPREADSHEET_ID,
+            range=range_notation,
+        )
+        result = _execute_with_throttle(request, context="collect_member_master")
+    except Exception as e:
+        logger.error("タダメンMマスタの読み取りエラー: %s", e)
+        return []
+
+    values = result.get("values", [])
+    indices = config.MEMBER_MASTER_COLUMN_INDICES
+
+    filtered = []
+    for row in values:
+        if not row or not row[0]:
+            continue
+        # 行の長さが足りない場合はNoneで埋める
+        padded = row + [None] * max(0, max(indices) + 1 - len(row))
+        extracted = [padded[i] for i in indices]
+        filtered.append(extracted)
+
+    logger.info("タダメンMマスタ: %d件のメンバーを取得しました", len(filtered))
+    return filtered
+
+
 def run_collection() -> dict[str, list[list]]:
     """データ収集のエントリポイント（シート収集のみ、グループ更新は /update-groups で実行）"""
     service = _build_sheets_service()

--- a/cloud-run/tests/test_member_master.py
+++ b/cloud-run/tests/test_member_master.py
@@ -1,0 +1,215 @@
+"""タダメンMマスタ収集のユニットテスト
+
+collect_member_master の列抽出・フィルタ・BQ投入を検証。
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+import config
+from sheets_collector import collect_member_master
+
+
+def _make_full_row(**overrides):
+    """タダメンMタブの50列分のダミー行を生成（A:AX = index 0~49）"""
+    row = [None] * 50
+    row[0] = overrides.get("member_id", "TM001")
+    row[1] = overrides.get("last_name", "田中")
+    row[2] = overrides.get("first_name", "太郎")
+    row[3] = overrides.get("last_name_kana", "タナカ")
+    row[4] = overrides.get("first_name_kana", "タロウ")
+    row[5] = overrides.get("nickname", "たろう")
+    row[8] = overrides.get("email", "tanaka@example.com")
+    row[9] = overrides.get("postal_code", "100-0001")
+    row[10] = overrides.get("prefecture", "東京都")
+    row[11] = overrides.get("address", "千代田区1-1")
+    row[14] = overrides.get("gws_account", "tanaka@tadakayo.jp")
+    row[15] = overrides.get("report_url_1", "https://docs.google.com/spreadsheets/d/url1")
+    row[16] = overrides.get("report_url_2", "https://docs.google.com/spreadsheets/d/url2")
+    row[19] = overrides.get("shipping_postal_code", "200-0001")
+    row[20] = overrides.get("shipping_address", "品川区2-2")
+    row[29] = overrides.get("qualification_allowance", "10000")
+    row[30] = overrides.get("position_rate", "1.5")
+    row[31] = overrides.get("corporate_sheet", "3")
+    row[32] = overrides.get("donation_sheet", "4")
+    row[33] = overrides.get("qualification_sheet", "5")
+    row[34] = overrides.get("bank1_type", "普通")
+    row[35] = overrides.get("bank1_name", "PayPay銀行")
+    row[36] = overrides.get("bank1_code", "0033")
+    row[37] = overrides.get("bank1_branch_name", "本店営業部")
+    row[38] = overrides.get("bank1_branch_code", "001")
+    row[39] = overrides.get("bank1_account_number", "1234567")
+    row[40] = overrides.get("bank1_deposit_type", "普通")
+    row[41] = overrides.get("bank1_holder_name", "タナカ タロウ")
+    row[42] = overrides.get("bank2_type", "普通")
+    row[43] = overrides.get("bank2_name", "GMOあおぞら")
+    row[44] = overrides.get("bank2_code", "0310")
+    row[45] = overrides.get("bank2_branch_name", "ネット支店")
+    row[46] = overrides.get("bank2_branch_code", "101")
+    row[47] = overrides.get("bank2_account_number", "7654321")
+    row[48] = overrides.get("bank2_deposit_type", "普通")
+    row[49] = overrides.get("bank2_holder_name", "タナカ タロウ")
+    return row
+
+
+class TestCollectMemberMaster:
+    """collect_member_master のテスト"""
+
+    def _mock_service(self, values):
+        service = MagicMock()
+        sheet_mock = MagicMock()
+        service.spreadsheets.return_value = sheet_mock
+        values_mock = MagicMock()
+        sheet_mock.values.return_value = values_mock
+        get_mock = MagicMock()
+        values_mock.get.return_value = get_mock
+        get_mock.execute.return_value = {"values": values}
+        return service, values_mock
+
+    def test_calls_correct_range(self):
+        """タダメンMタブのA2:AXを指定してSheets APIを呼ぶこと"""
+        service, values_mock = self._mock_service([])
+        collect_member_master(service)
+        values_mock.get.assert_called_once()
+        call_args = values_mock.get.call_args
+        assert call_args[1]["spreadsheetId"] == config.MEMBER_SPREADSHEET_ID
+        expected_range = f"'{config.MEMBER_MASTER_SHEET_NAME}'!A{config.MEMBER_MASTER_START_ROW}:AX"
+        assert call_args[1]["range"] == expected_range
+
+    def test_extracts_correct_columns(self):
+        """必要列のみ抽出されること（31列）"""
+        row = _make_full_row()
+        service, _ = self._mock_service([row])
+        result = collect_member_master(service)
+        assert len(result) == 1
+        extracted = result[0]
+        assert len(extracted) == len(config.MEMBER_MASTER_COLUMN_INDICES)
+        assert len(extracted) == 36
+
+    def test_column_values_match(self):
+        """抽出された値が正しい列に対応すること"""
+        row = _make_full_row(
+            member_id="TM999",
+            nickname="テスト",
+            bank1_name="みずほ銀行",
+            bank2_name="三菱UFJ",
+        )
+        service, _ = self._mock_service([row])
+        result = collect_member_master(service)
+        extracted = result[0]
+        # TABLE_COLUMNS の順序に従って検証
+        cols = config.TABLE_COLUMNS[config.BQ_TABLE_MEMBER_MASTER]
+        assert extracted[cols.index("member_id")] == "TM999"
+        assert extracted[cols.index("nickname")] == "テスト"
+        assert extracted[cols.index("bank1_name")] == "みずほ銀行"
+        assert extracted[cols.index("bank2_name")] == "三菱UFJ"
+
+    def test_report_url_and_bank_correspond(self):
+        """report_url_1とbank1_*、report_url_2とbank2_*が同一行で正しく対応すること"""
+        row = _make_full_row(
+            report_url_1="https://sheet1",
+            report_url_2="https://sheet2",
+            bank1_name="PayPay銀行",
+            bank1_account_number="1111111",
+            bank2_name="GMOあおぞら",
+            bank2_account_number="2222222",
+        )
+        service, _ = self._mock_service([row])
+        result = collect_member_master(service)
+        extracted = result[0]
+        cols = config.TABLE_COLUMNS[config.BQ_TABLE_MEMBER_MASTER]
+        assert extracted[cols.index("report_url_1")] == "https://sheet1"
+        assert extracted[cols.index("bank1_name")] == "PayPay銀行"
+        assert extracted[cols.index("bank1_account_number")] == "1111111"
+        assert extracted[cols.index("report_url_2")] == "https://sheet2"
+        assert extracted[cols.index("bank2_name")] == "GMOあおぞら"
+        assert extracted[cols.index("bank2_account_number")] == "2222222"
+
+    def test_skips_empty_member_id(self):
+        """member_id(A列)が空の行はスキップされること"""
+        row_valid = _make_full_row(member_id="TM001")
+        row_empty = _make_full_row(member_id="")
+        row_empty[0] = ""
+        row_none = []  # completely empty row
+        service, _ = self._mock_service([row_valid, row_empty, row_none])
+        result = collect_member_master(service)
+        assert len(result) == 1
+        cols = config.TABLE_COLUMNS[config.BQ_TABLE_MEMBER_MASTER]
+        assert result[0][cols.index("member_id")] == "TM001"
+
+    def test_short_row_padded(self):
+        """列数が足りない行もNoneで埋めて処理できること"""
+        short_row = ["TM001", "田中", "太郎"]  # 3列のみ
+        service, _ = self._mock_service([short_row])
+        result = collect_member_master(service)
+        assert len(result) == 1
+        assert len(result[0]) == 36
+        cols = config.TABLE_COLUMNS[config.BQ_TABLE_MEMBER_MASTER]
+        assert result[0][cols.index("member_id")] == "TM001"
+        assert result[0][cols.index("last_name")] == "田中"
+        assert result[0][cols.index("bank1_name")] is None
+
+    def test_api_error_returns_empty(self):
+        """Sheets APIエラー時は空リストを返すこと"""
+        service = MagicMock()
+        service.spreadsheets.return_value.values.return_value.get.side_effect = Exception("API error")
+        result = collect_member_master(service)
+        assert result == []
+
+    def test_column_count_matches_table_columns(self):
+        """MEMBER_MASTER_COLUMN_INDICES と TABLE_COLUMNS の長さが一致すること"""
+        assert len(config.MEMBER_MASTER_COLUMN_INDICES) == len(
+            config.TABLE_COLUMNS[config.BQ_TABLE_MEMBER_MASTER]
+        )
+
+
+class TestMainMemberMasterStep:
+    """main.py Step 7 のテスト"""
+
+    @patch("bq_loader.load_to_bigquery")
+    @patch("sheets_collector.collect_member_master")
+    @patch("sheets_collector._build_sheets_service")
+    @patch("sheets_collector.run_reimbursement_collection")
+    @patch("sheets_collector.update_member_groups_from_bq")
+    @patch("sheets_collector.run_collection")
+    def test_step7_failure_does_not_affect_main(
+        self, mock_run, mock_groups, mock_reimb, mock_build, mock_collect_mm, mock_bq_load
+    ):
+        """Step 7が失敗しても全体はsuccess"""
+        from main import app
+
+        mock_run.return_value = {"gyomu_reports": [], "hojo_reports": [], "members": []}
+        mock_groups.return_value = ([], [])
+        mock_reimb.return_value = {}
+        mock_collect_mm.side_effect = Exception("member_master collection failed")
+        mock_bq_load.return_value = 0
+
+        with app.test_client() as client:
+            resp = client.post("/")
+            assert resp.status_code == 200
+            data = resp.get_json()
+            assert data["status"] == "success"
+
+    @patch("bq_loader.load_to_bigquery")
+    @patch("sheets_collector.collect_member_master")
+    @patch("sheets_collector._build_sheets_service")
+    @patch("sheets_collector.run_reimbursement_collection")
+    @patch("sheets_collector.update_member_groups_from_bq")
+    @patch("sheets_collector.run_collection")
+    def test_step7_success_includes_count(
+        self, mock_run, mock_groups, mock_reimb, mock_build, mock_collect_mm, mock_bq_load
+    ):
+        """Step 7成功時にresultsにmember_masterのカウントが含まれる"""
+        from main import app
+
+        mock_run.return_value = {"gyomu_reports": [], "hojo_reports": [], "members": []}
+        mock_groups.return_value = ([], [])
+        mock_reimb.return_value = {}
+        mock_collect_mm.return_value = [["TM001"] + [None] * 30]
+        mock_bq_load.return_value = 1
+
+        with app.test_client() as client:
+            resp = client.post("/")
+            assert resp.status_code == 200
+            data = resp.get_json()
+            assert data["status"] == "success"

--- a/infra/bigquery/schema.sql
+++ b/infra/bigquery/schema.sql
@@ -144,6 +144,47 @@ CREATE TABLE IF NOT EXISTS `monthly-pay-tax.pay_reports.reimbursement_items` (
   ingested_at TIMESTAMP NOT NULL
 );
 
+-- タダメンMマスタ（タダメンMシートから全有用データを収集）
+CREATE TABLE IF NOT EXISTS `monthly-pay-tax.pay_reports.member_master` (
+  member_id STRING,
+  last_name STRING,
+  first_name STRING,
+  last_name_kana STRING,
+  first_name_kana STRING,
+  nickname STRING,
+  email STRING,
+  postal_code STRING,
+  prefecture STRING,
+  address STRING,
+  gws_account STRING,
+  report_url_1 STRING,
+  report_url_2 STRING,
+  shipping_postal_code STRING,
+  shipping_address STRING,
+  qualification_allowance STRING,
+  position_rate STRING,
+  corporate_sheet STRING,
+  donation_sheet STRING,
+  qualification_sheet STRING,
+  bank1_type STRING,
+  bank1_name STRING,
+  bank1_code STRING,
+  bank1_branch_name STRING,
+  bank1_branch_code STRING,
+  bank1_account_number STRING,
+  bank1_deposit_type STRING,
+  bank1_holder_name STRING,
+  bank2_type STRING,
+  bank2_name STRING,
+  bank2_code STRING,
+  bank2_branch_name STRING,
+  bank2_branch_code STRING,
+  bank2_account_number STRING,
+  bank2_deposit_type STRING,
+  bank2_holder_name STRING,
+  ingested_at TIMESTAMP NOT NULL
+);
+
 -- WAM対象PJマスタ（WAM判定ルール）
 CREATE TABLE IF NOT EXISTS `monthly-pay-tax.pay_reports.wam_target_projects` (
   target_project STRING NOT NULL,


### PR DESCRIPTION
## Summary
- タダメンMシートから口座情報・姓名・住所等36列を収集し、BQ `member_master` テーブルに格納
- 振込CSV口座自動化(#56)・支払調書(#58)の基盤データ
- 既存 `members` テーブル・VIEWは変更なし

## データ検証結果（Collector rev 00024-hgj）
| 指標 | 値 |
|------|-----|
| 総行数 | 240 |
| 口座①あり | 162 |
| 口座②あり | 10 |
| 姓あり | 235 |

## Test plan
- [x] Cloud Run 52テスト全PASS（新規10テスト含む）
- [x] Dashboard 235テスト全PASS（影響なし確認）
- [x] BQテーブル作成済み
- [x] Collector デプロイ・バッチ実行・240件収集確認
- [x] センシティブ列がダッシュボードUIに表示されないことをGrep確認（dashboard/に参照なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)