### PR TITLE
feat: 年間支払調書データ Tab追加 — member_master住所氏名JOIN

### DIFF
--- a/dashboard/_pages/wam_monthly.py
+++ b/dashboard/_pages/wam_monthly.py
@@ -126,6 +126,63 @@ def _load_bank_accounts() -> pd.DataFrame:
     return load_data(query)
 
 
+def _load_member_info() -> pd.DataFrame:
+    """member_masterから report_url → 氏名・住所のマッピングを取得（支払調書用）"""
+    query = f"""
+    SELECT report_url_1 AS report_url,
+           member_id, last_name, first_name, last_name_kana, first_name_kana,
+           postal_code, prefecture, address
+    FROM `{MEMBER_MASTER_TABLE}` WHERE report_url_1 IS NOT NULL AND report_url_1 != ''
+    UNION ALL
+    SELECT report_url_2 AS report_url,
+           member_id, last_name, first_name, last_name_kana, first_name_kana,
+           postal_code, prefecture, address
+    FROM `{MEMBER_MASTER_TABLE}` WHERE report_url_2 IS NOT NULL AND report_url_2 != ''
+    """
+    return load_data(query)
+
+
+def _build_annual_withholding_data(
+    df_comp_all: pd.DataFrame, year: int, df_member: pd.DataFrame
+) -> pd.DataFrame:
+    """年間支払調書データを構築
+
+    v_monthly_compensationの月別データを年間集計し、member_masterの氏名・住所をJOIN。
+    """
+    df_year = df_comp_all[df_comp_all["year"] == year].copy()
+    if df_year.empty:
+        return pd.DataFrame()
+
+    agg = df_year.groupby(["report_url", "nickname", "full_name"], dropna=False).agg(
+        年間報酬=("qualification_adjusted_compensation", "sum"),
+        年間源泉徴収=("withholding_tax", "sum"),
+        年間DX補助=("dx_subsidy", "sum"),
+        年間立替=("reimbursement", "sum"),
+        年間支払額=("payment", "sum"),
+    ).reset_index()
+
+    # member_master の氏名・住所をJOIN
+    if not df_member.empty:
+        agg = agg.merge(df_member, on="report_url", how="left")
+
+    return agg.sort_values("年間支払額", ascending=False, na_position="last")
+
+
+def _generate_withholding_csv(df: pd.DataFrame) -> bytes:
+    """支払調書用CSVを生成（UTF-8 BOM付き、Excel対応）"""
+    if df.empty:
+        return b""
+    cols = [
+        "member_id", "last_name", "first_name", "last_name_kana", "first_name_kana",
+        "postal_code", "prefecture", "address",
+        "nickname", "full_name",
+        "年間報酬", "年間源泉徴収", "年間DX補助", "年間立替", "年間支払額",
+    ]
+    out = df[[c for c in cols if c in df.columns]].copy()
+    csv_str = out.to_csv(index=False)
+    return b"\xef\xbb\xbf" + csv_str.encode("utf-8")
+
+
 def _generate_transfer_csv(df: pd.DataFrame, df_bank: pd.DataFrame) -> bytes:
     """GMOあおぞらネット銀行 総合振込CSVを生成（Shift_JIS、ヘッダーなし）
 
@@ -236,7 +293,7 @@ with cols[3]:
     render_kpi("領収書添付率", f"{stats['rate']:.0f}%")
 
 # --- タブ ---
-tab1, tab2, tab3, tab4, tab5 = st.tabs(["PJ別サマリー", "メンバー別明細", "領収書添付状況", "月別報酬・振込確認", "支払明細書"])
+tab1, tab2, tab3, tab4, tab5, tab6 = st.tabs(["PJ別サマリー", "メンバー別明細", "領収書添付状況", "月別報酬・振込確認", "支払明細書", "年間支払調書データ"])
 
 with tab1:
     st.subheader("対象PJ別 立替金サマリー")
@@ -485,3 +542,58 @@ with tab5:
                     with st.expander(f"添付書類一覧（{len(urls)}件）"):
                         for i, url in enumerate(urls, 1):
                             st.markdown(f"{i}. {url}")
+
+with tab6:
+    st.subheader("年間支払調書データ")
+    st.caption("メンバー別の年間報酬・源泉徴収合計＋氏名住所（支払調書作成用）")
+    if not comp_loaded:
+        st.warning("報酬データの取得に失敗しました")
+    else:
+        try:
+            df_member_info = _load_member_info()
+        except Exception:
+            df_member_info = pd.DataFrame()
+
+        df_annual = _build_annual_withholding_data(df_comp_all, selected_year, df_member_info)
+
+        if df_annual.empty:
+            st.info(f"{selected_year}年のデータがありません")
+        else:
+            # KPI
+            cols6 = st.columns(4)
+            with cols6[0]:
+                render_kpi("対象者数", f"{len(df_annual):,}")
+            with cols6[1]:
+                render_kpi("年間報酬合計", f"¥{df_annual['年間報酬'].sum():,.0f}")
+            with cols6[2]:
+                render_kpi("年間源泉徴収合計", f"¥{abs(df_annual['年間源泉徴収'].sum()):,.0f}")
+            with cols6[3]:
+                render_kpi("年間支払額合計", f"¥{df_annual['年間支払額'].sum():,.0f}")
+
+            # テーブル表示（口座情報は含めない）
+            display_cols = ["nickname", "full_name"]
+            if "last_name" in df_annual.columns:
+                display_cols += ["last_name", "first_name", "last_name_kana", "first_name_kana"]
+            if "postal_code" in df_annual.columns:
+                display_cols += ["postal_code", "prefecture", "address"]
+            display_cols += ["年間報酬", "年間源泉徴収", "年間DX補助", "年間立替", "年間支払額"]
+            df_display = df_annual[[c for c in display_cols if c in df_annual.columns]].copy()
+
+            # 金額列をフォーマット
+            for col in ["年間報酬", "年間源泉徴収", "年間DX補助", "年間立替", "年間支払額"]:
+                if col in df_display.columns:
+                    df_display[col] = df_display[col].apply(lambda x: f"¥{x:,.0f}")
+
+            st.dataframe(df_display, use_container_width=True, hide_index=True)
+            st.caption(f"{len(df_annual):,} 名表示（{selected_year}年 年間集計）")
+
+            # CSVダウンロード
+            csv_bytes = _generate_withholding_csv(df_annual)
+            st.download_button(
+                "支払調書データCSV",
+                csv_bytes,
+                file_name=f"withholding_data_{selected_year}.csv",
+                mime="text/csv",
+                key="wam_withholding_csv_download",
+            )
+            st.caption("※ 支払調書の正式作成には別途マイナンバー等の情報が必要です。")

--- a/dashboard/tests/test_pages_wam_monthly.py
+++ b/dashboard/tests/test_pages_wam_monthly.py
@@ -412,3 +412,129 @@ class TestDepositTypeCode:
 
     def test_with_whitespace(self):
         assert _deposit_type_code("  普通  ") == "1"
+
+
+# --- 年間支払調書データ ---
+
+def _build_annual_withholding_data(
+    df_comp_all: pd.DataFrame, year: int, df_member: pd.DataFrame
+) -> pd.DataFrame:
+    df_year = df_comp_all[df_comp_all["year"] == year].copy()
+    if df_year.empty:
+        return pd.DataFrame()
+    agg = df_year.groupby(["report_url", "nickname", "full_name"], dropna=False).agg(
+        年間報酬=("qualification_adjusted_compensation", "sum"),
+        年間源泉徴収=("withholding_tax", "sum"),
+        年間DX補助=("dx_subsidy", "sum"),
+        年間立替=("reimbursement", "sum"),
+        年間支払額=("payment", "sum"),
+    ).reset_index()
+    if not df_member.empty:
+        agg = agg.merge(df_member, on="report_url", how="left")
+    return agg.sort_values("年間支払額", ascending=False, na_position="last")
+
+
+def _generate_withholding_csv(df: pd.DataFrame) -> bytes:
+    if df.empty:
+        return b""
+    cols = [
+        "member_id", "last_name", "first_name", "last_name_kana", "first_name_kana",
+        "postal_code", "prefecture", "address",
+        "nickname", "full_name",
+        "年間報酬", "年間源泉徴収", "年間DX補助", "年間立替", "年間支払額",
+    ]
+    out = df[[c for c in cols if c in df.columns]].copy()
+    csv_str = out.to_csv(index=False)
+    return b"\xef\xbb\xbf" + csv_str.encode("utf-8")
+
+
+@pytest.fixture
+def annual_comp_df():
+    """年間報酬データ（複数月）"""
+    return pd.DataFrame({
+        "year": [2026, 2026, 2026, 2026, 2025],
+        "month": [1, 2, 1, 2, 12],
+        "nickname": ["太郎", "太郎", "花子", "花子", "太郎"],
+        "full_name": ["田中太郎", "田中太郎", "鈴木花子", "鈴木花子", "田中太郎"],
+        "report_url": ["url_t", "url_t", "url_h", "url_h", "url_t"],
+        "qualification_adjusted_compensation": [100000.0, 120000.0, 50000.0, 60000.0, 80000.0],
+        "withholding_tax": [-10210.0, -12252.0, -5105.0, -6126.0, -8168.0],
+        "dx_subsidy": [0.0, 0.0, 5000.0, 3000.0, 0.0],
+        "reimbursement": [10000.0, 0.0, 0.0, 2000.0, 5000.0],
+        "payment": [99790.0, 107748.0, 49895.0, 58874.0, 76832.0],
+    })
+
+
+@pytest.fixture
+def member_info_df():
+    """member_master氏名・住所データ"""
+    return pd.DataFrame({
+        "report_url": ["url_t", "url_h"],
+        "member_id": ["TM001", "TM002"],
+        "last_name": ["田中", "鈴木"],
+        "first_name": ["太郎", "花子"],
+        "last_name_kana": ["タナカ", "スズキ"],
+        "first_name_kana": ["タロウ", "ハナコ"],
+        "postal_code": ["100-0001", "200-0002"],
+        "prefecture": ["東京都", "神奈川県"],
+        "address": ["千代田区1-1", "横浜市2-2"],
+    })
+
+
+class TestBuildAnnualWithholdingData:
+    def test_aggregates_by_year(self, annual_comp_df, member_info_df):
+        """年間集計が正しいこと"""
+        result = _build_annual_withholding_data(annual_comp_df, 2026, member_info_df)
+        assert len(result) == 2  # 太郎 + 花子
+        taro = result[result["nickname"] == "太郎"].iloc[0]
+        assert taro["年間報酬"] == 220000.0  # 100000 + 120000
+        assert taro["年間源泉徴収"] == -22462.0  # -10210 + -12252
+        assert taro["年間支払額"] == 207538.0  # 99790 + 107748
+
+    def test_member_info_joined(self, annual_comp_df, member_info_df):
+        """member_masterの氏名・住所がJOINされること"""
+        result = _build_annual_withholding_data(annual_comp_df, 2026, member_info_df)
+        taro = result[result["nickname"] == "太郎"].iloc[0]
+        assert taro["last_name"] == "田中"
+        assert taro["postal_code"] == "100-0001"
+        assert taro["address"] == "千代田区1-1"
+
+    def test_no_data_for_year(self, annual_comp_df, member_info_df):
+        """対象年のデータがない場合は空DataFrame"""
+        result = _build_annual_withholding_data(annual_comp_df, 2024, member_info_df)
+        assert result.empty
+
+    def test_without_member_info(self, annual_comp_df):
+        """member_infoなしでも集計は動作すること"""
+        result = _build_annual_withholding_data(annual_comp_df, 2026, pd.DataFrame())
+        assert len(result) == 2
+        assert "last_name" not in result.columns
+
+    def test_sorted_by_payment_desc(self, annual_comp_df, member_info_df):
+        """支払額降順でソートされること"""
+        result = _build_annual_withholding_data(annual_comp_df, 2026, member_info_df)
+        payments = result["年間支払額"].tolist()
+        assert payments == sorted(payments, reverse=True)
+
+
+class TestGenerateWithholdingCsv:
+    def test_basic_csv(self, annual_comp_df, member_info_df):
+        """CSVが正しく生成されること"""
+        df = _build_annual_withholding_data(annual_comp_df, 2026, member_info_df)
+        csv_bytes = _generate_withholding_csv(df)
+        assert csv_bytes[:3] == b"\xef\xbb\xbf"  # BOM
+        csv_text = csv_bytes[3:].decode("utf-8")
+        assert "member_id" in csv_text
+        assert "田中" in csv_text
+        assert "220000" in csv_text
+
+    def test_empty(self):
+        assert _generate_withholding_csv(pd.DataFrame()) == b""
+
+    def test_without_member_columns(self, annual_comp_df):
+        """member_info未JOINでもCSV生成できること"""
+        df = _build_annual_withholding_data(annual_comp_df, 2026, pd.DataFrame())
+        csv_bytes = _generate_withholding_csv(df)
+        csv_text = csv_bytes[3:].decode("utf-8")
+        assert "nickname" in csv_text
+        assert "member_id" not in csv_text  # JOINされていないので含まれない


### PR DESCRIPTION
## Summary
- WAM立替金ページに Tab 6「年間支払調書データ」を追加
- v_monthly_compensation を年間集計 → メンバー別の年間報酬・源泉徴収・支払額を算出
- member_master から姓名・住所・フリガナを report_url で JOIN
- CSVダウンロード（UTF-8 BOM付き、Excel対応）
- 口座情報はUIに表示しない（支払調書に必要な住所・氏名のみ）
- #58 の部分実装（外部ツール連携は所在確認後）

Related: #58

## 変更内容
| ファイル | 変更 |
|---------|------|
| `dashboard/_pages/wam_monthly.py` | `_load_member_info()`, `_build_annual_withholding_data()`, `_generate_withholding_csv()` 追加、Tab 6 実装 |
| `dashboard/tests/test_pages_wam_monthly.py` | 年間集計・member_info JOIN・CSV生成のテスト 8件追加 |

## Test plan
- [x] Dashboard 252テスト PASS
- [ ] デプロイ後: Tab 6 で年間集計データが表示されること
- [ ] デプロイ後: CSVダウンロードに氏名・住所が含まれること
- [ ] デプロイ後: 口座情報が表示されていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)