### PR TITLE
fix: Tab 6 テーブル表示から個人情報を除外

### DIFF
--- a/dashboard/_pages/wam_monthly.py
+++ b/dashboard/_pages/wam_monthly.py
@@ -570,12 +570,8 @@ with tab6:
             with cols6[3]:
                 render_kpi("年間支払額合計", f"¥{df_annual['年間支払額'].sum():,.0f}")
 
-            # テーブル表示（口座情報は含めない）
-            display_cols = ["nickname", "full_name"]
-            if "last_name" in df_annual.columns:
-                display_cols += ["last_name", "first_name", "last_name_kana", "first_name_kana"]
-            if "postal_code" in df_annual.columns:
-                display_cols += ["postal_code", "prefecture", "address"]
+            # テーブル表示（個人情報は非表示 — 氏名・住所はCSVのみ）
+            display_cols = ["nickname"]
             display_cols += ["年間報酬", "年間源泉徴収", "年間DX補助", "年間立替", "年間支払額"]
             df_display = df_annual[[c for c in display_cols if c in df_annual.columns]].copy()
 


### PR DESCRIPTION
## Summary
- 年間支払調書データ(Tab 6)の表示テーブルから氏名・住所等の個人情報列を除外
- UI表示はnicknameと金額列のみ
- CSVダウンロードには従来通り氏名・住所を含める（経理の支払調書作成用途）

## 理由
member_masterのデータはセンシティブ → ダッシュボードUI（ドラフト）には一切表示しない方針

🤖 Generated with [Claude Code](https://claude.com/claude-code)