### PR TITLE
docs: ドキュメントページ全面更新 — architecture/help/CLAUDE.md 最新化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,10 @@ Cloud Scheduler (0 6 * * * JST, OIDC認証)
       → BigQuery pay_reports.members.groups (UPDATE)
     Step 5: dashboard_usersグループ同期
       → BigQuery pay_reports.dashboard_users (MERGE/DELETE: source_group由来ユーザーの追加・削除)
+    Step 6: 立替金シート収集
+      → BigQuery pay_reports.reimbursement_items (WRITE_TRUNCATE)
+    Step 7: タダメンMマスタ全量取得
+      → BigQuery pay_reports.member_master (WRITE_TRUNCATE, 36列×240件, センシティブデータ含む)
 ```
 
 認証はWorkload Identity + IAM signBlob APIによるキーレスDomain-Wide Delegation。
@@ -27,27 +31,30 @@ SA鍵ファイルは使わない（ローカル開発時のみ `SA_KEY_PATH` 環
 ## ディレクトリ構成
 
 - `cloud-run/` - Cloud Runアプリケーション（本体）
-  - `main.py` - Flaskエントリポイント（`POST /` でバッチ実行、`GET /health`）
-  - `sheets_collector.py` - Sheets API経由のデータ収集（DWD認証含む）
+  - `main.py` - Flaskエントリポイント（`POST /` バッチ実行 Step1-7、`POST /update-groups`、`GET /health`）
+  - `sheets_collector.py` - Sheets API経由のデータ収集（DWD認証含む、立替金シート・タダメンMマスタ収集）
   - `bq_loader.py` - BigQueryへのデータロード（pandas DataFrame経由）
   - `config.py` - GCPプロジェクトID、BQテーブル名、マスタスプレッドシートID等の設定値
-  - `tests/` - ユニットテスト（42テスト: Sheets APIスロットリング、グループ一覧、dashboard_users同期、立替金シート収集）
+  - `tests/` - ユニットテスト（52テスト: Sheets APIスロットリング、グループ一覧、dashboard_users同期、立替金シート収集、タダメンM収集）
 - `dashboard/` - Streamlitダッシュボード（マルチページ構成）
   - `app.py` - エントリポイント（認証 + st.navigation ルーター）
-  - `pages/dashboard.py` - 4タブ（月別報酬サマリー/スポンサー別業務委託費/業務報告一覧/グループ別）
-  - `pages/check_management.py` - 業務チェック管理表（checker/admin専用、BQ DML）
-  - `pages/architecture.py` - Mermaidアーキテクチャ図
-  - `pages/user_management.py` - ユーザー管理（admin専用、BQ DML）
-  - `pages/admin_settings.py` - 管理設定（admin専用）
-  - `pages/help.py` - ヘルプ/マニュアル
+  - `_pages/dashboard.py` - 5タブ（月別報酬サマリー/スポンサー別業務委託費/業務報告一覧/グループ別/業務委託費分析）
+  - `_pages/report_input.py` - 報告入力（業務報告・補助報告のアプリ入力プロトタイプ）
+  - `_pages/check_management.py` - 業務チェック管理表（checker/admin専用、BQ DML）
+  - `_pages/wam_monthly.py` - WAM立替金確認（admin専用、6タブ: PJ別サマリー/メンバー別明細/領収書添付状況/月別報酬・振込確認/支払明細書PDF/年間支払調書データ）
+  - `_pages/architecture.py` - Mermaidアーキテクチャ図
+  - `_pages/user_management.py` - ユーザー管理（admin専用、BQ DML）
+  - `_pages/admin_settings.py` - 管理設定（admin専用）
+  - `_pages/help.py` - ヘルプ/マニュアル
   - `lib/auth.py` - Streamlit OIDC認証 + BQホワイトリスト照合
   - `lib/bq_client.py` - 共有BQクライアント
+  - `lib/receipt_pdf.py` - 支払明細書PDF生成
   - `lib/styles.py` - 共有CSS
   - `lib/constants.py` - 定数
   - `lib/ui_helpers.py` - 共通UIユーティリティ（KPI表示・数値変換・年月セレクタ）
 - `コード.js` - 旧GASコード（参照用、稼働していない）
 - `infra/bigquery/schema.sql` - BQテーブルスキーマ定義（dashboard_users, check_logs含む）
-  - `infra/bigquery/views.sql` - BQ VIEW定義（v_gyomu_enriched, v_hojo_enriched, v_monthly_compensation）
+  - `infra/bigquery/views.sql` - BQ VIEW定義（v_gyomu_enriched, v_hojo_enriched, v_monthly_compensation, v_reimbursement_enriched）
 - `infra/ar-cleanup-policy.json` - Artifact Registryクリーンアップポリシー
 - `docs/adr/` - Architecture Decision Records
 - `docs/handoff/LATEST.md` - ハンドオフドキュメント
@@ -152,13 +159,14 @@ GASバインドSSのスプレッドシート関数パイプラインをSQLで再
 
 | ページ | ファイル | アクセス権 |
 |--------|---------|-----------|
-| ダッシュボード（4タブ） | `pages/dashboard.py` | viewer/checker/admin |
-| 業務チェック | `pages/check_management.py` | checker/admin |
-| アーキテクチャ | `pages/architecture.py` | viewer/checker/admin |
-| ヘルプ | `pages/help.py` | viewer/checker/admin |
-| WAM立替金確認（3タブ） | `pages/wam_monthly.py` | adminのみ |
-| ユーザー管理 | `pages/user_management.py` | adminのみ |
-| 管理設定 | `pages/admin_settings.py` | adminのみ |
+| ダッシュボード（5タブ） | `_pages/dashboard.py` | user/checker/admin |
+| 報告入力 | `_pages/report_input.py` | user/checker/admin |
+| 業務チェック | `_pages/check_management.py` | checker/admin |
+| アーキテクチャ | `_pages/architecture.py` | user/checker/admin |
+| ヘルプ | `_pages/help.py` | user/checker/admin |
+| WAM立替金確認（6タブ） | `_pages/wam_monthly.py` | adminのみ |
+| ユーザー管理 | `_pages/user_management.py` | adminのみ |
+| 管理設定 | `_pages/admin_settings.py` | adminのみ |
 
 ### 認証フロー
 

--- a/dashboard/_pages/architecture.py
+++ b/dashboard/_pages/architecture.py
@@ -73,27 +73,34 @@ st.markdown("""
 render_mermaid("""
 graph LR
     CS[Cloud Scheduler<br/>毎朝6時 JST] -->|OIDC認証| CR[Cloud Run<br/>pay-collector]
-    CR -->|Sheets API v4<br/>キーレスDWD| SS[(190個の<br/>スプレッドシート)]
+    CR -->|Step1-3: Sheets API v4<br/>キーレスDWD| SS[(190個の<br/>スプレッドシート)]
     CR -->|WRITE_TRUNCATE| BQ[(BigQuery<br/>pay_reports)]
-    CR -->|Admin Directory API| ADK[Google Admin SDK<br/>グループ情報]
+    CR -->|Step4: Admin Directory API| ADK[Google Admin SDK<br/>グループ情報]
     ADK -->|groups_master / members更新| BQ
     CR -->|Step5: グループ同期| DU[dashboard_users<br/>自動追加/削除]
     DU --> BQ
+    CR -->|Step6: 立替金シート巡回| RS[立替金シート<br/>reimbursement_items]
+    RS --> BQ
+    CR -->|Step7: タダメンM取得| MM[member_master<br/>240件]
+    MM --> BQ
     BQ -->|VIEWs| DB[Cloud Run<br/>pay-dashboard]
     BR[ブラウザ] -->|HTTPS *.run.app| DB
     DB -->|Streamlit OIDC<br/>Google OAuth| GOOG[Google IdP<br/>tadakayo.jp]
-""", height=380)
+""", height=420)
 
 st.markdown("""
 | コンポーネント | 仕様 |
 |:---|:---|
-| Collector | Python 3.12 / Flask / gunicorn / 2GiB |
-| Dashboard | Python 3.12 / Streamlit / 512MiB（5タブ: 月別報酬サマリー / スポンサー別業務委託費 / 業務報告一覧 / グループ別 / 業務委託費分析） |
+| Collector | Python 3.12 / Flask / gunicorn / 2GiB（Step 1-7: SS巡回 → BQ投入 → グループ → 同期 → 立替金 → タダメンM） |
+| Dashboard | Python 3.12 / Streamlit / 512MiB（7ページ: ダッシュボード5タブ / 報告入力 / 業務チェック / WAM立替金確認6タブ / アーキテクチャ / ヘルプ / ユーザー管理 / 管理設定） |
 | Collector認証 | Workload Identity + IAM signBlob (キーレスDWD) |
 | Dashboard認証 | Streamlit OIDC (Google OAuth, tadakayo.jpドメイン) |
 | BQ取り込み | WRITE_TRUNCATE（毎回全データ置換）|
-| グループ更新 | 毎朝バッチ末尾に Admin Directory API でグループ情報を自動更新 |
-| ユーザー同期 | グループ由来のdashboard_usersをグループメンバーと自動同期（追加/削除） |
+| BQスキーマ | 10テーブル + 4 VIEW |
+| グループ更新 | Step4: Admin Directory API でグループ情報を自動更新 |
+| ユーザー同期 | Step5: グループ由来のdashboard_usersをグループメンバーと自動同期（追加/削除） |
+| 立替金収集 | Step6: 立替金シートを巡回し reimbursement_items テーブルへ投入 |
+| メンバーマスタ | Step7: 管理表タダメンMタブから member_master（36列×240件）を全量取得 |
 """)
 
 
@@ -101,38 +108,44 @@ st.markdown("""
 st.subheader("2. データフロー")
 st.markdown("""
 管理表から190件のスプレッドシートURLを取得し、各シートから業務報告(gyomu)と補助報告(hojo)を収集します。
-メンバーマスタ(members)は管理表のA:K列から取得。
+メンバーマスタ(members)は管理表のA:K列から取得。立替金シートとタダメンMマスタも定期収集しています。
 """)
 
 render_mermaid("""
 graph TD
     MGR[管理表<br/>URLリスト + メンバーマスタ] -->|URL一覧| COL[Collector]
-    COL -->|各SSを巡回| G[gyomu_reports<br/>~14,000行]
-    COL -->|各SSを巡回| H[hojo_reports<br/>~950行]
+    COL -->|Step1-2: 各SSを巡回| G[gyomu_reports<br/>~14,000行]
+    COL -->|Step1-2: 各SSを巡回| H[hojo_reports<br/>~950行]
     MGR -->|A:K列| M[members<br/>192行 + groups列]
-    ADK[Admin Directory API] -->|グループ所属| GM[groups_master<br/>69グループ]
+    ADK[Admin Directory API] -->|Step4: グループ所属| GM[groups_master<br/>69グループ]
     ADK -->|groups列更新| M
-    ADK -->|グループメンバー同期| DU[dashboard_users<br/>グループ由来ユーザー<br/>自動追加/削除]
+    ADK -->|Step5: グループメンバー同期| DU[dashboard_users<br/>グループ由来ユーザー<br/>自動追加/削除]
+    COL -->|Step6: 立替金シート巡回| RI[reimbursement_items<br/>~2,250行]
+    MGR -->|Step7: タダメンMタブ| MM[member_master<br/>36列×240件]
     WT[withholding_targets<br/>源泉対象リスト] -.->|手動管理| BQ
+    WTP[wam_target_projects<br/>WAM対象PJマスタ] -.->|手動管理| BQ
     G --> BQ[(BigQuery)]
     H --> BQ
     M --> BQ
     GM --> BQ
     DU --> BQ
+    RI --> BQ
+    MM --> BQ
     BQ --> VG[v_gyomu_enriched]
     BQ --> VH[v_hojo_enriched]
     VG --> VMC[v_monthly_compensation]
     VH --> VMC
+    BQ --> VRE[v_reimbursement_enriched]
     DB[Dashboard] -->|checker/admin操作| CL[check_logs]
     DB -->|admin: グループ一括登録| DU
     CL --> BQ
-""", height=700)
+""", height=780)
 
 
 # === 3. BQスキーマ ER図 ===
 st.subheader("3. BQスキーマ")
 st.markdown("""
-7テーブル + 3 VIEW。`source_url = report_url` でメンバー結合。
+10テーブル + 4 VIEW。`source_url = report_url` でメンバー結合。`member_master`は口座・住所等のセンシティブデータを含む（UI非表示、CSV出力のみ）。
 """)
 
 render_mermaid("""
@@ -140,6 +153,8 @@ erDiagram
     gyomu_reports ||--o{ members : "source_url = report_url"
     hojo_reports ||--o{ members : "source_url = report_url"
     check_logs ||--o{ members : "source_url = report_url"
+    reimbursement_items ||--o{ members : "source_url = report_url"
+    member_master ||--o{ members : "member_id"
     gyomu_reports {
         STRING source_url
         STRING year
@@ -166,6 +181,27 @@ erDiagram
         STRING qualification_allowance
         STRING groups
     }
+    reimbursement_items {
+        STRING source_url
+        STRING nickname
+        STRING date
+        STRING target_project
+        STRING category
+        STRING payment_amount
+        STRING receipt_url
+    }
+    member_master {
+        STRING member_id
+        STRING nickname
+        STRING email
+        STRING bank1_bank_name
+        STRING bank1_account_number
+    }
+    wam_target_projects {
+        STRING target_project
+        STRING wam_flag
+        STRING note
+    }
     withholding_targets {
         STRING work_category
         STRING licensed_member_id
@@ -189,7 +225,8 @@ erDiagram
         STRING group_email
         STRING group_name
     }
-""", height=750)
+    reimbursement_items }o--|| wam_target_projects : "target_project"
+""", height=950)
 
 
 # === 4. VIEW計算チェーン ===
@@ -221,20 +258,44 @@ st.markdown("""
 | with_tax | 源泉対象額と源泉徴収を計算 | withholding_target_amount, withholding_tax |
 """)
 
+# === 4.5 v_reimbursement_enriched ===
+st.subheader("4.5 v_reimbursement_enriched")
+st.markdown("""
+立替金シート明細にメンバー情報とWAM対象PJ判定を結合するVIEW。WAM立替金確認ページのデータソース。
+""")
+
+render_mermaid("""
+graph LR
+    RI[reimbursement_items] -->|nickname JOIN| M[members]
+    RI -->|target_project JOIN| WTP[wam_target_projects]
+    M --> VRE[v_reimbursement_enriched<br/>立替金 + メンバー + WAM判定]
+    WTP --> VRE
+""", height=250)
+
+st.markdown("""
+| 結合元 | 結合キー | 追加情報 |
+|:---|:---|:---|
+| reimbursement_items | ベーステーブル | 立替金明細（日付、対象PJ、金額、領収書URL等） |
+| members | nickname | member_id, report_url, gws_account |
+| wam_target_projects | target_project | wam_flag（WAM対象PJかどうか） |
+""")
+
 
 # === 5. ダッシュボード ページ構成 ===
 st.subheader("5. ダッシュボード ページ構成")
 st.markdown("""
 マルチページ構成（`st.navigation`）。ロールによってアクセスできるページが異なります。
-ダッシュボードページは5タブで構成されています。
+ロールは `user` / `checker` / `admin` の3段階です。
 """)
 
 render_mermaid("""
 graph TD
-    APP[pay-dashboard<br/>Streamlit App] --> P1[ダッシュボード<br/>viewer / checker / admin]
+    APP[pay-dashboard<br/>Streamlit App] --> P1[ダッシュボード 5タブ<br/>全ロール]
+    APP --> P1B[報告入力<br/>全ロール]
     APP --> P2[業務チェック<br/>checker / admin]
-    APP --> P3[アーキテクチャ<br/>viewer / checker / admin]
-    APP --> P4[ヘルプ<br/>viewer / checker / admin]
+    APP --> P3[アーキテクチャ<br/>全ロール]
+    APP --> P4[ヘルプ<br/>全ロール]
+    APP --> P7[WAM立替金確認 6タブ<br/>admin のみ]
     APP --> P5[ユーザー管理<br/>admin のみ]
     APP --> P6[管理設定<br/>admin のみ]
 
@@ -243,7 +304,14 @@ graph TD
     P1 --> T3[業務報告一覧<br/>全明細フィルタ/検索]
     P1 --> T4[グループ別<br/>メンバー一覧/月別報酬/業務報告]
     P1 --> T5[業務委託費分析<br/>分類別集計/非営利活動]
-""", height=520)
+
+    P7 --> W1[PJ別サマリー]
+    P7 --> W2[メンバー別明細]
+    P7 --> W3[領収書添付状況]
+    P7 --> W4[月別報酬・振込確認]
+    P7 --> W5[支払明細書PDF]
+    P7 --> W6[年間支払調書データ]
+""", height=700)
 
 
 # === 6. 認証フロー ===
@@ -257,9 +325,9 @@ graph TD
     GOOG -->|st.user.email| APP
     APP -->|email照合| BQ[(BQ dashboard_users)]
     BQ -->|未登録| DENY[アクセス拒否]
-    BQ -->|viewer| VIEW[ダッシュボード<br/>+ アーキテクチャ<br/>+ ヘルプ]
+    BQ -->|user| VIEW[ダッシュボード<br/>+ 報告入力<br/>+ アーキテクチャ<br/>+ ヘルプ]
     BQ -->|checker| CHECK[上記 +<br/>業務チェック管理表]
-    BQ -->|admin| ADMIN[上記 +<br/>ユーザー管理<br/>+ 管理設定]
+    BQ -->|admin| ADMIN[上記 +<br/>WAM立替金確認<br/>+ ユーザー管理<br/>+ 管理設定]
     ADMIN -->|グループ一括登録| GRP[groups_master<br/>からメンバー取得]
     GRP -->|MERGE INSERT| BQ
     BQ -->|BQ障害時| FB{フォールバック}
@@ -287,7 +355,7 @@ graph TD
     end
 
     subgraph AUTHZ["認可層"]
-        RBAC[RBAC 3段階<br/>viewer / checker / admin]
+        RBAC[RBAC 3段階<br/>user / checker / admin]
         WL[ホワイトリスト<br/>BQ dashboard_users<br/>登録メールのみ許可]
     end
 

--- a/dashboard/_pages/help.py
+++ b/dashboard/_pages/help.py
@@ -162,6 +162,8 @@ HELP_CSS = """
 .pg > div:nth-child(4) { animation-delay: 0.32s; }
 .pg > div:nth-child(5) { animation-delay: 0.40s; }
 .pg > div:nth-child(6) { animation-delay: 0.48s; }
+.pg > div:nth-child(7) { animation-delay: 0.56s; }
+.pg > div:nth-child(8) { animation-delay: 0.64s; }
 .pc {
     border-radius: 13px;
     padding: 1.2rem;
@@ -409,7 +411,13 @@ st.markdown("""
     <div class="pc b">
         <div class="pc-icon">📊</div>
         <h3>ダッシュボード</h3>
-        <p>月別報酬サマリー、スポンサー別業務委託費、業務報告一覧、グループ別の4タブで全体を把握</p>
+        <p>月別報酬サマリー、スポンサー別業務委託費、業務報告一覧、グループ別、業務委託費分析の5タブで全体を把握</p>
+        <span class="badge ba">全ユーザー</span>
+    </div>
+    <div class="pc b">
+        <div class="pc-icon">📝</div>
+        <h3>報告入力</h3>
+        <p>業務報告（日次）・補助報告（月次）をダッシュボードから直接入力</p>
         <span class="badge ba">全ユーザー</span>
     </div>
     <div class="pc g">
@@ -429,6 +437,12 @@ st.markdown("""
         <h3>ヘルプ</h3>
         <p>このページ。操作ガイド・用語集・よくある質問</p>
         <span class="badge ba">全ユーザー</span>
+    </div>
+    <div class="pc pr">
+        <div class="pc-icon">💰</div>
+        <h3>WAM立替金確認</h3>
+        <p>立替金シートデータ・月別報酬の確認、振込CSV・支払明細書PDF・年間支払調書の出力</p>
+        <span class="badge bp">admin のみ</span>
     </div>
     <div class="pc pr">
         <div class="pc-icon">👥</div>
@@ -479,6 +493,7 @@ st.markdown("""
             <li>スポンサー別: スポンサー名</li>
             <li>業務報告一覧: 活動分類・業務分類</li>
             <li>グループ別: グループ名・業務分類</li>
+            <li>業務委託費分析: 業務委託費全体/非営利活動</li>
             <li>各タブ独立で動作</li>
         </ul>
     </div>
@@ -649,9 +664,9 @@ with st.expander("アクセス権限を追加してほしい"):
     **admin（管理者）** に依頼してください。
     管理者は「ユーザー管理」ページからメールアドレスを登録できます。
 
-    - **viewer**: ダッシュボード閲覧のみ
-    - **checker**: ダッシュボード閲覧 + 業務チェック管理
-    - **admin**: 全機能（ユーザー管理・管理設定を含む）
+    - **user**: ダッシュボード閲覧 + 報告入力
+    - **checker**: 上記 + 業務チェック管理
+    - **admin**: 全機能（WAM立替金確認・ユーザー管理・管理設定を含む）
 
     対象は **tadakayo.jpドメイン** のGWSアカウントのみです。
     """)

--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,42 +1,39 @@
 # ハンドオフメモ - monthly-pay-tax
 
-**更新日**: 2026-04-13（振込CSV口座自動化 + 年間支払調書データ + 個人情報非表示修正）
+**更新日**: 2026-04-13（ドキュメントページ全面更新 — architecture.py / help.py / CLAUDE.md 最新化）
 **フェーズ**: WAM助成金対応 **技術側完了** — 残りはステークホルダー回答待ちのみ
 **最新デプロイ**: Collector rev 00024-hgj + Dashboard rev **00230-n6j**
 **Cloud Run設定**: 2026-04-07 `--no-cpu-throttling --max-instances=3` 適用済み（ADR 0004）
 **テストスイート**: Dashboard 252 + Cloud Run 52 = **304テスト全PASS**
 
-## 🆕 2026-04-13 振込CSV口座自動化 + 年間支払調書データ
+## 🆕 2026-04-13 ドキュメントページ全面更新
 
-### PR #96: 振込CSV口座自動化 (Closes #92)
+### ドキュメント最新化（未コミット → PR予定）
 
-member_masterテーブルのbank1/bank2情報をreport_urlで結合し、
-振込CSV(GMOあおぞら形式)の銀行番号・支店番号・口座番号・名義を自動入力。
+architecture.py / help.py / CLAUDE.md を現在のシステム状態に完全同期。
 
-**実装**:
-- `_load_bank_accounts()`: report_url_1→bank1_*, report_url_2→bank2_* のUNIONクエリ
-- `_generate_transfer_csv()`: 口座データをLEFT JOINしてCSV出力
-- `_safe_str()`: NaN/None対策、`_deposit_type_code()`: 預金種目→数値コード変換
-- マッチしないメンバーは空欄フォールバック（手動補完可能）
+**architecture.py の主な修正**:
+- 全体構成図: Step 6（立替金シート）, Step 7（タダメンM）追加
+- データフロー図: reimbursement_items, member_master, wam_target_projects, v_reimbursement_enriched 追加
+- BQスキーマ: 「7テーブル + 3 VIEW」→「10テーブル + 4 VIEW」、ER図に3テーブル追加
+- v_reimbursement_enriched VIEW の新セクション追加
+- ページ構成図: 「報告入力」「WAM立替金確認(6タブ)」追加
+- 認証フロー・セキュリティ: ロール名 viewer → user 修正
 
-### PR #97: 年間支払調書データ Tab追加 (#58 部分実装)
+**help.py の主な修正**:
+- ページ一覧: 「報告入力」「WAM立替金確認」カード追加（6→8枚）
+- ダッシュボード「4タブ」→「5タブ」
+- タブ内フィルター: 「業務委託費分析」説明追加
+- FAQ: ロール名 viewer → user 修正
 
-WAM立替金ページに Tab 6「年間支払調書データ」を追加。
+**CLAUDE.md の主な修正**:
+- アーキテクチャ図に Step 6-7 追加
+- ディレクトリ構成: pages/ → _pages/、全ページ反映、lib/receipt_pdf.py 追加
+- ページ構成テーブル: 5タブ/6タブ反映、ロール名修正
 
-**実装**:
-- `_load_member_info()`: member_masterから氏名・住所をreport_urlでマッピング
-- `_build_annual_withholding_data()`: v_monthly_compensationを年間集計→member_master JOIN
-- `_generate_withholding_csv()`: UTF-8 BOM付きCSV（Excel対応）
-- KPI: 対象者数 / 年間報酬合計 / 年間源泉徴収合計 / 年間支払額合計
+### 前回セッション（PR #96-#100）
 
-### PR #99: Tab 6 個人情報非表示修正
-
-**方針**: member_master由来の個人情報（氏名・住所・フリガナ）はダッシュボードUIに一切表示しない。
-- UIテーブル: nickname + 金額列のみ
-- CSVダウンロード: 氏名・住所を含める（経理の支払調書作成用途）
-- 口座情報: CSVファイル内のみ（振込CSV）
-
-### PR #98: CLAUDE.md テスト件数更新 252テスト
+振込CSV口座自動化 + 年間支払調書データ + 個人情報非表示修正（詳細は git log 参照）
 
 ---
 


### PR DESCRIPTION
## Summary
- architecture.py: Step 6-7（立替金シート・タダメンM）追加、10テーブル+4VIEW反映、ER図3テーブル追加、v_reimbursement_enriched新セクション、報告入力/WAM立替金確認ページ追加、ロール名修正(viewer→user)
- help.py: ページ一覧8枚化（報告入力/WAM追加）、5タブ反映、ロール名修正
- CLAUDE.md: アーキテクチャ図Step 6-7、_pages/パス修正、全ページ・lib反映、ページ構成テーブル更新

## Test plan
- [x] Dashboard 252テスト PASS
- [x] Cloud Run 52テスト PASS
- [ ] デプロイ後にarchitecture/helpページの表示確認（Mermaid図の描画・レイアウト崩れなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)