### PR TITLE
docs: WAM立替金確認の操作ガイド追加 + ページ数/タブ名修正

### DIFF
--- a/dashboard/_pages/architecture.py
+++ b/dashboard/_pages/architecture.py
@@ -92,7 +92,7 @@ st.markdown("""
 | コンポーネント | 仕様 |
 |:---|:---|
 | Collector | Python 3.12 / Flask / gunicorn / 2GiB（Step 1-7: SS巡回 → BQ投入 → グループ → 同期 → 立替金 → タダメンM） |
-| Dashboard | Python 3.12 / Streamlit / 512MiB（7ページ: ダッシュボード5タブ / 報告入力 / 業務チェック / WAM立替金確認6タブ / アーキテクチャ / ヘルプ / ユーザー管理 / 管理設定） |
+| Dashboard | Python 3.12 / Streamlit / 512MiB（8ページ: ダッシュボード5タブ / 報告入力 / 業務チェック / WAM立替金確認6タブ / アーキテクチャ / ヘルプ / ユーザー管理 / 管理設定） |
 | Collector認証 | Workload Identity + IAM signBlob (キーレスDWD) |
 | Dashboard認証 | Streamlit OIDC (Google OAuth, tadakayo.jpドメイン) |
 | BQ取り込み | WRITE_TRUNCATE（毎回全データ置換）|
@@ -309,7 +309,7 @@ graph TD
     P7 --> W2[メンバー別明細]
     P7 --> W3[領収書添付状況]
     P7 --> W4[月別報酬・振込確認]
-    P7 --> W5[支払明細書PDF]
+    P7 --> W5[支払明細書]
     P7 --> W6[年間支払調書データ]
 """, height=700)
 

--- a/dashboard/_pages/help.py
+++ b/dashboard/_pages/help.py
@@ -603,6 +603,115 @@ st.markdown("""
 
 
 # ============================================================
+# WAM立替金確認ガイド
+# ============================================================
+st.markdown("""
+<div class="sh">
+    <div class="sh-icon purple">💰</div>
+    <h2>WAM立替金確認の使い方</h2>
+</div>
+""", unsafe_allow_html=True)
+
+st.markdown(
+    "立替金シートのデータ確認、振込CSV出力、支払明細書PDF生成、年間支払調書データ出力を行うページです。"
+    "**admin** ロールが必要です。"
+)
+
+st.markdown("""
+<div class="tip">
+    <div class="tip-t">📥 データの仕組み</div>
+    <div class="tip-c">
+        立替金データは、各メンバーのスプレッドシートから<strong>毎朝6時に自動収集</strong>されます。<br>
+        収集された明細はBigQuery（reimbursement_items）に格納され、WAM対象PJ判定と結合して表示されます。
+    </div>
+</div>
+""", unsafe_allow_html=True)
+
+# 6タブ説明テーブル
+st.markdown("""
+<table class="ct">
+<thead>
+    <tr><th>タブ</th><th>内容</th><th>操作</th></tr>
+</thead>
+<tbody>
+    <tr>
+        <td><strong>PJ別サマリー</strong></td>
+        <td>対象PJ別の立替金集計（件数・支払金額・仮払金額）</td>
+        <td class="cr">閲覧のみ</td>
+    </tr>
+    <tr>
+        <td><strong>メンバー別明細</strong></td>
+        <td>メンバーごとの立替経費明細（日付・PJ・分類・金額）</td>
+        <td class="ce">✏️ CSVダウンロード</td>
+    </tr>
+    <tr>
+        <td><strong>領収書添付状況</strong></td>
+        <td>メンバー別の領収書添付率（KPI + 未添付数ソート）</td>
+        <td class="cr">閲覧のみ</td>
+    </tr>
+    <tr>
+        <td><strong>月別報酬・振込確認</strong></td>
+        <td>月別の報酬集計（対象メンバー数・報酬・源泉・支払額）</td>
+        <td class="ce">✏️ 報酬明細CSV / 振込CSV（GMOあおぞら形式）</td>
+    </tr>
+    <tr>
+        <td><strong>支払明細書</strong></td>
+        <td>メンバー別の支払明細書プレビュー（業務委託費 + 立替経費）</td>
+        <td class="ce">✏️ PDF生成 / ZIP一括生成</td>
+    </tr>
+    <tr>
+        <td><strong>年間支払調書データ</strong></td>
+        <td>メンバー別の年間報酬・源泉徴収集計</td>
+        <td class="ce">✏️ CSVダウンロード（BOM付UTF-8）</td>
+    </tr>
+</tbody>
+</table>
+""", unsafe_allow_html=True)
+
+# WAM操作フロー
+st.markdown("""
+<div class="sh">
+    <div class="sh-icon purple">📋</div>
+    <h2>WAM立替金確認の進め方</h2>
+</div>
+""", unsafe_allow_html=True)
+
+st.markdown("""
+<div class="steps">
+    <div class="step" style="border-color: rgba(139,92,246,0.15); background: linear-gradient(170deg, rgba(139,92,246,0.06) 0%, transparent 60%);">
+        <div class="step-num" style="background: linear-gradient(135deg, #8B5CF6, #7C3AED);">1</div>
+        <h3>期間・PJを選択</h3>
+        <p>サイドバーで年月を選択。対象PJフィルターやWAM対象チェックボックスで絞り込めます。</p>
+    </div>
+    <div class="step" style="border-color: rgba(139,92,246,0.15); background: linear-gradient(170deg, rgba(139,92,246,0.06) 0%, transparent 60%);">
+        <div class="step-num" style="background: linear-gradient(135deg, #8B5CF6, #7C3AED);">2</div>
+        <h3>明細・領収書を確認</h3>
+        <p>PJ別サマリー・メンバー別明細で金額を確認。領収書添付状況で未添付のメンバーをチェック。</p>
+    </div>
+    <div class="step" style="border-color: rgba(139,92,246,0.15); background: linear-gradient(170deg, rgba(139,92,246,0.06) 0%, transparent 60%);">
+        <div class="step-num" style="background: linear-gradient(135deg, #8B5CF6, #7C3AED);">3</div>
+        <h3>CSV/PDF出力</h3>
+        <p>振込CSVで銀行振込データを出力。支払明細書PDFを個別またはZIP一括で生成。年間支払調書CSVで税務用データを出力。</p>
+    </div>
+</div>
+""", unsafe_allow_html=True)
+
+# WAM操作ティップス
+st.markdown("""
+<div class="tip">
+    <div class="tip-t">💡 操作のコツ</div>
+    <div class="tip-c">
+        ・振込CSVはGMOあおぞらネット銀行の総合振込フォーマット（Shift_JIS）です<br>
+        ・口座情報はタダメンMマスタから自動取得されます（手入力不要）<br>
+        ・支払明細書は「全メンバー」選択でZIP一括生成、個別選択で1枚ずつ生成できます<br>
+        ・年間支払調書CSVはBOM付きUTF-8のため、Excelで直接開いても文字化けしません<br>
+        ・個人情報（氏名・住所・口座）は画面に表示されず、CSV/PDFファイル出力のみに含まれます
+    </div>
+</div>
+""", unsafe_allow_html=True)
+
+
+# ============================================================
 # データ用語集
 # ============================================================
 st.markdown("""
@@ -627,6 +736,11 @@ st.markdown("""
     <div class="gi"><div class="gi-t">当月入力完了</div><div class="gi-d">メンバーがSSで当月分の入力完了を申告した状態</div></div>
     <div class="gi"><div class="gi-t">DX領収書</div><div class="gi-d">DX補助用の領収書添付欄の記入状況</div></div>
     <div class="gi"><div class="gi-t">立替領収書</div><div class="gi-d">個人立替用の領収書添付欄（立替シート利用者はシート添付欄）</div></div>
+    <div class="gi"><div class="gi-t">WAM</div><div class="gi-d">立替金管理の対象プロジェクト判定の仕組み。wam_target_projectsマスタで管理</div></div>
+    <div class="gi"><div class="gi-t">対象PJ</div><div class="gi-d">立替金が紐づくプロジェクト名。WAM対象かどうかはマスタで判定</div></div>
+    <div class="gi"><div class="gi-t">振込CSV</div><div class="gi-d">GMOあおぞらネット銀行の総合振込用データ（Shift_JIS形式）</div></div>
+    <div class="gi"><div class="gi-t">支払明細書</div><div class="gi-d">メンバー別の業務委託費+立替経費の内訳をまとめたPDF帳票</div></div>
+    <div class="gi"><div class="gi-t">年間支払調書</div><div class="gi-d">メンバー別の年間報酬・源泉徴収の集計データ（税務用CSV出力）</div></div>
 </div>
 """, unsafe_allow_html=True)
 
@@ -689,6 +803,24 @@ with st.expander("業務チェックのステータスが保存されません")
     2. **競合**: 別のチェック者が同じメンバーを同時に更新した場合、競合エラーが発生します。
        ページを再読み込みしてから再度操作してください。
     3. **ネットワーク**: 通信エラーの場合はしばらく待ってから再試行してください
+    """)
+
+with st.expander("WAM立替金確認にデータが表示されません"):
+    st.markdown("""
+    以下を確認してください:
+
+    1. **ロール**: admin ロールが必要です（checker/userでは表示されません）
+    2. **期間**: サイドバーの年月選択が正しいか確認してください
+    3. **立替金シート**: 対象メンバーのスプレッドシートに立替金シートが存在するか確認してください
+    4. **収集タイミング**: データは毎朝6時に自動収集されます。当日入力分は翌朝の反映です
+    """)
+
+with st.expander("振込CSVの口座情報が空です"):
+    st.markdown("""
+    振込CSVの口座情報はタダメンMマスタ（member_master）から自動取得されます。
+
+    口座が空の場合、管理表のタダメンMタブに該当メンバーの口座情報が未登録の可能性があります。
+    管理表で口座情報を登録すれば、翌朝のバッチ処理後に反映されます。
     """)
 
 with st.expander("デプロイ後にページが正しく表示されません"):

--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,35 +1,30 @@
 # ハンドオフメモ - monthly-pay-tax
 
-**更新日**: 2026-04-13（ドキュメントページ全面更新 — architecture.py / help.py / CLAUDE.md 最新化）
+**更新日**: 2026-04-13（ドキュメントページ追加修正 — WAM操作ガイド追加 / ページ数・タブ名修正）
 **フェーズ**: WAM助成金対応 **技術側完了** — 残りはステークホルダー回答待ちのみ
 **最新デプロイ**: Collector rev 00024-hgj + Dashboard rev **00230-n6j**
 **Cloud Run設定**: 2026-04-07 `--no-cpu-throttling --max-instances=3` 適用済み（ADR 0004）
 **テストスイート**: Dashboard 252 + Cloud Run 52 = **304テスト全PASS**
 
-## 🆕 2026-04-13 ドキュメントページ全面更新
+## 🆕 2026-04-13 ドキュメントページ追加修正
 
-### ドキュメント最新化（未コミット → PR予定）
+### 修正内容（#101 マージ済み + 追加修正）
 
-architecture.py / help.py / CLAUDE.md を現在のシステム状態に完全同期。
+**PR #101（マージ済み）**: architecture.py / help.py / CLAUDE.md を現在のシステム状態に完全同期。
 
-**architecture.py の主な修正**:
-- 全体構成図: Step 6（立替金シート）, Step 7（タダメンM）追加
-- データフロー図: reimbursement_items, member_master, wam_target_projects, v_reimbursement_enriched 追加
-- BQスキーマ: 「7テーブル + 3 VIEW」→「10テーブル + 4 VIEW」、ER図に3テーブル追加
-- v_reimbursement_enriched VIEW の新セクション追加
-- ページ構成図: 「報告入力」「WAM立替金確認(6タブ)」追加
-- 認証フロー・セキュリティ: ロール名 viewer → user 修正
+**追加修正（未コミット → PR予定）**:
 
-**help.py の主な修正**:
-- ページ一覧: 「報告入力」「WAM立替金確認」カード追加（6→8枚）
-- ダッシュボード「4タブ」→「5タブ」
-- タブ内フィルター: 「業務委託費分析」説明追加
-- FAQ: ロール名 viewer → user 修正
+architecture.py:
+- コンポーネント表「7ページ」→「8ページ」修正
+- WAM Mermaid図 Tab5「支払明細書PDF」→「支払明細書」修正
 
-**CLAUDE.md の主な修正**:
-- アーキテクチャ図に Step 6-7 追加
-- ディレクトリ構成: pages/ → _pages/、全ページ反映、lib/receipt_pdf.py 追加
-- ページ構成テーブル: 5タブ/6タブ反映、ロール名修正
+help.py — WAM立替金確認の操作ガイド新規追加:
+- 6タブの機能説明テーブル（PJ別サマリー〜年間支払調書データ）
+- データ収集の仕組み説明（毎朝6時の自動収集）
+- 3ステップ操作ガイド（期間選択→明細確認→CSV/PDF出力）
+- 操作のコツ（振込CSV形式、口座自動取得、ZIP一括、BOM付UTF-8、個人情報取扱い）
+- 用語集にWAM関連5用語追加（WAM/対象PJ/振込CSV/支払明細書/年間支払調書）
+- FAQに2問追加（WAMデータ非表示/振込CSV口座空）
 
 ### 前回セッション（PR #96-#100）
 


### PR DESCRIPTION
## Summary
- ヘルプページにWAM立替金確認の操作ガイドを新規追加（6タブ説明・3ステップガイド・操作のコツ・用語集・FAQ）
- アーキテクチャページのページ数（7→8）とWAMタブ名（支払明細書PDF→支払明細書）を修正
- ハンドオフドキュメント更新

## Test plan
- [x] Dashboard 252テスト全PASS
- [ ] デプロイ後にヘルプページのWAMセクション表示確認
- [ ] アーキテクチャページのMermaid図・コンポーネント表の表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)