### PR TITLE
fix: WAM Tab2 から領収書列を削除（collector URL取得未対応・暫定）

### DIFF
--- a/dashboard/_pages/wam_monthly.py
+++ b/dashboard/_pages/wam_monthly.py
@@ -320,7 +320,6 @@ with tab2:
             build_tab2_display_df(df_detail),
             column_config={
                 "URL": st.column_config.LinkColumn(display_text="開く"),
-                "領収書": st.column_config.LinkColumn(display_text="開く"),
             },
             use_container_width=True,
             hide_index=True,

--- a/dashboard/lib/wam_helpers.py
+++ b/dashboard/lib/wam_helpers.py
@@ -12,13 +12,15 @@ TAB2_CSV_COLS = [
     "payment_purpose", "payment_amount", "advance_amount",
     "from_station", "to_station", "visit_purpose",
 ]
-TAB2_DISPLAY_COLS = TAB2_CSV_COLS + ["source_url", "receipt_url"]
+# receipt_url は collector が =HYPERLINK() の表示テキストのみ取得しており URL 化されていないため、
+# collector 改修まではリンク列として扱わない（#TODO: 別Issue で改修）
+TAB2_DISPLAY_COLS = TAB2_CSV_COLS + ["source_url"]
 TAB2_COL_LABELS = {
     "nickname": "メンバー", "date": "月日", "target_project": "対象PJ",
     "is_wam": "WAM対象", "category": "分類", "payment_purpose": "支払用途",
     "payment_amount": "支払金額", "advance_amount": "仮払金額",
     "from_station": "発", "to_station": "着", "visit_purpose": "訪問目的",
-    "source_url": "URL", "receipt_url": "領収書",
+    "source_url": "URL",
 }
 
 
@@ -33,9 +35,8 @@ def build_tab2_display_df(df_detail: pd.DataFrame) -> pd.DataFrame:
     existing = [c for c in TAB2_DISPLAY_COLS if c in df_detail.columns]
     df_display = df_detail[existing].rename(columns=TAB2_COL_LABELS).copy()
     # LinkColumn は "nan"/空文字も href として描画するため、空欄化してリンク化を抑止
-    for url_col in ("URL", "領収書"):
-        if url_col in df_display.columns:
-            df_display[url_col] = df_display[url_col].apply(_safe_url)
+    if "URL" in df_display.columns:
+        df_display["URL"] = df_display["URL"].apply(_safe_url)
     return df_display
 
 

--- a/dashboard/tests/test_pages_wam_monthly.py
+++ b/dashboard/tests/test_pages_wam_monthly.py
@@ -557,9 +557,10 @@ class TestTab2DisplayDf:
         assert "URL" in result.columns
         assert "source_url" not in result.columns
 
-    def test_receipt_column_renamed(self, sample_df):
+    def test_receipt_column_excluded(self, sample_df):
+        # collector が HYPERLINK の URL を取得できていないため受領書列は出さない
         result = build_tab2_display_df(sample_df)
-        assert "領収書" in result.columns
+        assert "領収書" not in result.columns
         assert "receipt_url" not in result.columns
 
     def test_url_normalized_for_nan_none_empty_nan_string(self):
@@ -575,14 +576,6 @@ class TestTab2DisplayDf:
                 float("nan"),
                 "  ",
             ],
-            "receipt_url": [
-                None,
-                "https://example.com/r2",
-                "  ",
-                "nan",
-                "",
-                float("nan"),
-            ],
         })
         result = build_tab2_display_df(df)
         assert result.iloc[0]["URL"] == "https://example.com/1"
@@ -591,30 +584,21 @@ class TestTab2DisplayDf:
         assert result.iloc[3]["URL"] == ""
         assert result.iloc[4]["URL"] == ""
         assert result.iloc[5]["URL"] == ""
-        assert result.iloc[0]["領収書"] == ""
-        assert result.iloc[1]["領収書"] == "https://example.com/r2"
-        assert result.iloc[2]["領収書"] == ""
-        assert result.iloc[3]["領収書"] == ""
-        assert result.iloc[4]["領収書"] == ""
-        assert result.iloc[5]["領収書"] == ""
 
     def test_missing_url_columns_no_error(self):
-        """source_url / receipt_url がないDFでもエラーにならない"""
+        """source_url がないDFでもエラーにならない"""
         df = pd.DataFrame({"nickname": ["A"], "date": ["1/1"]})
         result = build_tab2_display_df(df)
         assert "URL" not in result.columns
-        assert "領収書" not in result.columns
         assert "メンバー" in result.columns
 
 
 class TestTab2CsvDf:
     def test_url_columns_excluded_from_csv(self, sample_df):
-        # CSV は既存仕様維持のため URL/領収書 列を含めない
+        # CSV は既存仕様維持のため URL 列を含めない
         result = build_tab2_csv_df(sample_df)
         assert "URL" not in result.columns
-        assert "領収書" not in result.columns
         assert "source_url" not in result.columns
-        assert "receipt_url" not in result.columns
 
     def test_csv_existing_columns_preserved(self, sample_df):
         # 既存のCSV列構成が維持される（sample_dfに含まれる列のみ）
@@ -624,15 +608,11 @@ class TestTab2CsvDf:
                 assert TAB2_COL_LABELS[orig_col] in result.columns
 
     def test_display_df_column_order_stable(self, sample_df):
-        # 表示用DFの列順がリファクタで崩れないことを担保（CSV列 → URL → 領収書）
+        # 表示用DFの列順がリファクタで崩れないことを担保（CSV列 → URL）
         result = build_tab2_display_df(sample_df)
         actual = list(result.columns)
         expected_csv_labels = [
             TAB2_COL_LABELS[c] for c in TAB2_CSV_COLS if c in sample_df.columns
         ]
-        url_labels = [
-            TAB2_COL_LABELS[c]
-            for c in ("source_url", "receipt_url")
-            if c in sample_df.columns
-        ]
-        assert actual == expected_csv_labels + url_labels
+        url_label = ["URL"] if "source_url" in sample_df.columns else []
+        assert actual == expected_csv_labels + url_label


### PR DESCRIPTION
## Summary
PR #103 で追加した「領収書」LinkColumn が機能しない問題を暫定修正。

### 根本原因
`receipt_url` の BQ 値が collector の `formattedValue` 取得仕様により、
`=HYPERLINK("url", "ファイル名")` の **表示テキスト（ファイル名）のみ** 入っており、
Drive URL は取得できていない。LinkColumn に渡しても href が無効。

例（実データ）:
\`\`\`
receipt_url = "ミヤヤ_ラクスル_20241211.pdf"  ← URL ではない
\`\`\`

### 修正内容
- 「領収書」列を Tab2 表示から削除（collector 改修までの暫定処置）
- `column_config` から該当 LinkColumn 削除
- テスト調整（領収書列が含まれないことをアサート）

`source_url`（立替金シート、正規URL）の「URL」列は維持。

### 中期対応（別Issue化予定）
collector で `=HYPERLINK()` の URL 部分を取得するロジック追加:
- Sheets API の `userEnteredValue` から数式解析、または `hyperlink` 属性取得
- BQ に Drive URL が入った時点で本PRをrevert相当（列を再追加）すれば復活

## Test plan
- [x] `python3 -m pytest dashboard/tests/ -q` → 259 passed
- [ ] マージ後: Cloud Build → Cloud Run deploy → admin で領収書列が消えていることを確認