### PR TITLE
feat: admin_settings BQテーブル一覧に立替金・タダメンマスタ等を追加

### DIFF
--- a/dashboard/_pages/admin_settings.py
+++ b/dashboard/_pages/admin_settings.py
@@ -37,7 +37,12 @@ with col2:
 # === BQテーブル情報 ===
 st.subheader("BigQuery テーブル情報")
 
-tables = ["gyomu_reports", "hojo_reports", "members", "withholding_targets", "dashboard_users", "check_logs", "groups_master"]
+tables = [
+    "gyomu_reports", "hojo_reports", "reimbursement_items",
+    "members", "member_master",
+    "withholding_targets", "wam_target_projects",
+    "dashboard_users", "check_logs", "groups_master",
+]
 
 try:
     client = get_bq_client()


### PR DESCRIPTION
## Summary
admin_settings ページの「BigQuery テーブル情報」一覧に、CLAUDE.md記載スキーマの10テーブル全てを表示。
立替金（reimbursement_items）・タダメンMマスタ（member_master）・WAM対象PJ（wam_target_projects）の
データ収録タイミング（最終更新時刻）を admin が確認できるようにする。

## 変更
- `dashboard/_pages/admin_settings.py` の `tables` リストに3テーブル追加
  - `reimbursement_items`
  - `member_master`
  - `wam_target_projects`
- 並びをデータ系/メンバー系/マスタ系/運用系で整理

## Test plan
- [x] `python3 -m pytest dashboard/tests/ -q` → 259 passed
- [x] BQ で全テーブル存在確認済み（`bq ls monthly-pay-tax:pay_reports`）
- [ ] マージ後デプロイ → admin_settings で10テーブル全表示確認